### PR TITLE
Fix: Remove import

### DIFF
--- a/src/Faker/GeneratorTrait.php
+++ b/src/Faker/GeneratorTrait.php
@@ -3,7 +3,6 @@
 namespace Refinery29\Test\Util\Faker;
 
 use Faker\Factory;
-use Faker\Generator;
 use Refinery29\Test\Util\Faker\Provider\Color;
 
 trait GeneratorTrait


### PR DESCRIPTION
This PR

* [x] removes an import, effectively resolving to `Generator` within the current namespace, providing auto-completion for added formatters