### PR TITLE
Fix: Require only PHP5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 matrix:
   fast_finish: true
   include:
+    - php: 5.4
     - php: 5.5
     - php: 5.6
       env: CHECK_CS=true COLLECT_COVERAGE=true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.4"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a0ddc5ab3002ca6fe3e4a2cc1a6769ee",
-    "content-hash": "c29025088dfb8153ae17dcc5ad54856f",
+    "hash": "0aa92a058af047967614a91511079c2e",
+    "content-hash": "d46c6d312869c1ae95a53c86563d4237",
     "packages": [],
     "packages-dev": [
         {
@@ -1720,7 +1720,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=5.4"
     },
     "platform-dev": []
 }

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -2,16 +2,14 @@
 
 namespace Refinery29\Test\Util\Test\Faker;
 
-use Faker\Generator as BaseGenerator;
-use Refinery29\Test\Util\Faker\Generator;
 use ReflectionClass;
 
 class GeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testExtendsBase()
     {
-        $reflectionClass = new ReflectionClass(Generator::class);
+        $reflectionClass = new ReflectionClass('Refinery29\Test\Util\Faker\Generator');
 
-        $this->assertTrue($reflectionClass->isSubclassOf(BaseGenerator::class));
+        $this->assertTrue($reflectionClass->isSubclassOf('Faker\Generator'));
     }
 }

--- a/test/Faker/GeneratorTraitTest.php
+++ b/test/Faker/GeneratorTraitTest.php
@@ -51,10 +51,14 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
     {
         $reflectionClass = new ReflectionClass('Refinery29\Test\Util\Faker\Provider\Color');
 
+        $data = [];
+
         foreach ($reflectionClass->getMethods() as $method) {
-            yield [
+            $data[] = [
                 $method->getName(),
             ];
         }
+
+        return $data;
     }
 }

--- a/test/Faker/GeneratorTraitTest.php
+++ b/test/Faker/GeneratorTraitTest.php
@@ -2,9 +2,7 @@
 
 namespace Refinery29\Test\Util\Test\Faker;
 
-use Faker\Generator;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
-use Refinery29\Test\Util\Faker\Provider\Color;
 use ReflectionClass;
 
 class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
@@ -15,7 +13,7 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $this->assertInstanceOf(Generator::class, $faker);
+        $this->assertInstanceOf('Faker\Generator', $faker);
     }
 
     public function testGetFakerReturnsTheSameInstance()
@@ -42,7 +40,7 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
         $callable = $method->invoke($faker, $formatter);
 
         $this->assertInternalType('array', $callable);
-        $this->assertInstanceOf(Color::class, $callable[0]);
+        $this->assertInstanceOf('Refinery29\Test\Util\Faker\Provider\Color', $callable[0]);
         $this->assertSame($formatter, $callable[1]);
     }
 
@@ -51,7 +49,7 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function providerHasColorProviderAttached()
     {
-        $reflectionClass = new ReflectionClass(Color::class);
+        $reflectionClass = new ReflectionClass('Refinery29\Test\Util\Faker\Provider\Color');
 
         foreach ($reflectionClass->getMethods() as $method) {
             yield [


### PR DESCRIPTION
This PR

* [x] runs a build on PHP5.4
* [x] decreases the minimum required PHP version to 5.4
* [x] removes usages of the `class` keyword
* [x] removes usages of `yield`