### PR TITLE
Fix: Run build using highest dependencies available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   include:
     - php: 5.5
     - php: 5.6
+      env: WITH_DEPENDENCIES=highest
+    - php: 5.6
       env: WITH_CS=true
     - php: 7
       env: WITH_COVERAGE=true
@@ -30,7 +32,7 @@ before_install:
   - composer config github-oauth.github.com $GITHUB_TOKEN
 
 install:
-  - composer install --prefer-dist
+  - if [ "$WITH_DEPENDENCIES" == "highest" ]; then composer update --prefer-dist; else composer install --prefer-dist; fi
 
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"


### PR DESCRIPTION
This PR

* [x] runs one additional build on PHP5.6 using the highest dependencies available

Follows #17.