### PR TITLE
Fix: Make it first target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Run
 $ make test
 ```
 
-to run all of the test suites.
+to run all the tests.
 
 ### Coding Standards
 
@@ -31,3 +31,13 @@ $ make cs
 ```
 
 to automatically fix coding standard violations.
+
+## Extra lazy?
+
+Run
+
+```
+$ make
+```
+
+to run both coding standards check and tests!

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+it: cs test
+
 composer:
 	composer validate
 	composer install
@@ -7,8 +9,6 @@ coverage: composer
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff
-
-it: cs test
 
 test: composer
 	vendor/bin/phpunit --configuration phpunit.xml --columns max


### PR DESCRIPTION
This PR

* [x] makes `it` the first target