### PR TITLE
Fix: Allow to retrieve Faker statically

### DIFF
--- a/src/Faker/GeneratorTrait.php
+++ b/src/Faker/GeneratorTrait.php
@@ -17,7 +17,7 @@ trait GeneratorTrait
     /**
      * @return Generator
      */
-    protected function getFaker()
+    protected static function getFaker()
     {
         static $faker;
 

--- a/test/Faker/GeneratorTraitTest.php
+++ b/test/Faker/GeneratorTraitTest.php
@@ -23,6 +23,13 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Faker\Generator', $faker);
     }
 
+    public function testCanGetFakerStatically()
+    {
+        $faker = self::getFaker();
+
+        $this->assertInstanceOf('Faker\Generator', $faker);
+    }
+
     public function testGetFakerReturnsTheSameInstance()
     {
         $faker = $this->getFaker();


### PR DESCRIPTION
This PR

* [x] allows to retrieve an instance of `Faker\Generator` statically