### PR TITLE
Enhancement: Implement InvalidUrl provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php": ">=5.5"
     },
     "require-dev": {
+        "beberlei/assert": "^2.4",
         "codeclimate/php-test-reporter": "0.2.0",
         "fzaninotto/faker": "^1.5",
         "phpunit/phpunit": "^4.8.18 || ^5.2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,10 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "876a77fca4eb82c773625445b3ce1f48",
-    "content-hash": "21b84a6a8a3a817fb72d36bdb5b89675",
+    "hash": "d1d1d78db290b2d40f143279d0efa4a5",
+    "content-hash": "5c1a660523a3289c22d13084de0631fa",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "@stable"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Assert": "lib/"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2015-08-21 16:50:17"
+        },
         {
             "name": "codeclimate/php-test-reporter",
             "version": "v0.2.0",
@@ -130,7 +183,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/a674d597cf248dbfad467a2609f6a5cd2ff65e44",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7876ff1df77e519083c3fc72c38eb9085342a994",
                 "reference": "a674d597cf248dbfad467a2609f6a5cd2ff65e44",
                 "shasum": ""
             },

--- a/src/DataProvider/InvalidUrl.php
+++ b/src/DataProvider/InvalidUrl.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+use Generator;
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+use stdClass;
+
+class InvalidUrl implements DataProviderInterface
+{
+    use GeneratorTrait;
+
+    /**
+     * @return array|Generator
+     */
+    public function data()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            null,
+            $faker->boolean(),
+            $faker->word,
+            $faker->words,
+            $faker->randomNumber(),
+            $faker->randomFloat(),
+            new stdClass(),
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Assert\Assertion;
+use InvalidArgumentException;
+use Refinery29\Test\Util\DataProvider\DataProviderInterface;
+use Refinery29\Test\Util\DataProvider\InvalidUrl;
+
+class InvalidUrlTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsDataProviderInterface()
+    {
+        $dataProvider = new InvalidUrl();
+
+        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrl::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAUrl($value)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        Assertion::url($value);
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires `beberlei/assert`
* [x] implements an `InvalidUrl`provider

Follows #21.

:information_desk_person: The idea is to make generic data providers reusable!