### PR TITLE
Enhancement: Extract AbstractDataProvider

### DIFF
--- a/src/DataProvider/AbstractDataProvider.php
+++ b/src/DataProvider/AbstractDataProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+
+abstract class AbstractDataProvider implements DataProviderInterface
+{
+    use GeneratorTrait;
+
+    /**
+     * @return array
+     */
+    abstract protected function values();
+
+    public function data()
+    {
+        foreach ($this->values() as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+}

--- a/src/DataProvider/InvalidBoolean.php
+++ b/src/DataProvider/InvalidBoolean.php
@@ -10,21 +10,18 @@
 namespace Refinery29\Test\Util\DataProvider;
 
 use Generator;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
 use stdClass;
 
-class InvalidBoolean implements DataProviderInterface
+class InvalidBoolean extends AbstractDataProvider
 {
-    use GeneratorTrait;
-
     /**
      * @return array|Generator
      */
-    public function data()
+    protected function values()
     {
         $faker = $this->getFaker();
 
-        $values = [
+        return [
             null,
             $faker->randomFloat(),
             $faker->randomNumber(),
@@ -32,11 +29,5 @@ class InvalidBoolean implements DataProviderInterface
             $faker->words,
             new stdClass(),
         ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
     }
 }

--- a/src/DataProvider/InvalidString.php
+++ b/src/DataProvider/InvalidString.php
@@ -10,21 +10,18 @@
 namespace Refinery29\Test\Util\DataProvider;
 
 use Generator;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
 use stdClass;
 
-class InvalidString implements DataProviderInterface
+class InvalidString extends AbstractDataProvider
 {
-    use GeneratorTrait;
-
     /**
      * @return array|Generator
      */
-    public function data()
+    protected function values()
     {
         $faker = $this->getFaker();
 
-        $values = [
+        return [
             null,
             $faker->boolean(),
             $faker->randomFloat(),
@@ -32,11 +29,5 @@ class InvalidString implements DataProviderInterface
             $faker->words,
             new stdClass(),
         ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
     }
 }

--- a/src/DataProvider/InvalidUrl.php
+++ b/src/DataProvider/InvalidUrl.php
@@ -9,22 +9,15 @@
 
 namespace Refinery29\Test\Util\DataProvider;
 
-use Generator;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
 use stdClass;
 
-class InvalidUrl implements DataProviderInterface
+class InvalidUrl extends AbstractDataProvider
 {
-    use GeneratorTrait;
-
-    /**
-     * @return array|Generator
-     */
-    public function data()
+    protected function values()
     {
         $faker = $this->getFaker();
 
-        $values = [
+        return [
             null,
             $faker->boolean(),
             $faker->word,
@@ -33,11 +26,5 @@ class InvalidUrl implements DataProviderInterface
             $faker->randomFloat(),
             new stdClass(),
         ];
-
-        foreach ($values as $value) {
-            yield [
-                $value,
-            ];
-        }
     }
 }


### PR DESCRIPTION
This PR

* [x] extracts an `AbstractDataProvider`

:person_with_pouting_face: Since we're not limited to PHP7, we can't yield from other generators, so this provides a way of extending providers (saves duplication, right)?