### PR TITLE
Fix: Add missing code of conduct

### DIFF
--- a/.github/CONDUCT.md
+++ b/.github/CONDUCT.md
@@ -1,0 +1,32 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we 
+pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, 
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level 
+of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, 
+race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+* Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, 
+  issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, 
+  project maintainers commit themselves to fairly and consistently applying these principles to every aspect of 
+  managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently 
+  removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the 
+project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting 
+one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.2.0, available from 
+http://contributor-covenant.org/version/1/2/0/

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ class BazTest extends \PHPUnit_Framework_TestCase
 
 Please have a look at [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
+## Code of Conduct
+
+Please have a look at [CONDUCT.md](.github/CONDUCT.md).
+
 ## License
 
 This package is licensed using the MIT License.


### PR DESCRIPTION
This PR

* [x] adds a missing code of conduct
