### PR TITLE
Fix: Broaden allowed return values

### DIFF
--- a/src/DataProvider/DataProviderInterface.php
+++ b/src/DataProvider/DataProviderInterface.php
@@ -9,12 +9,15 @@
 
 namespace Refinery29\Test\Util\DataProvider;
 
-use Generator;
+use Traversable;
 
 interface DataProviderInterface
 {
     /**
-     * @return array|Generator
+     * This method should return an array or a Traversable, iterating over which should return an array of arguments to
+     * pass to a test method that makes use of the concrete data provider.
+     *
+     * @return array|Traversable
      */
     public function data();
 }


### PR DESCRIPTION
This PR

* [x] broadens the type of values which need to be returned by `data()` of a data provider

:information_desk_person: Who cares if a `Generator` (or an `Iterator`) is returned as long as we can traverse through the return value?