### PR TITLE
Enhancement: Extract DataProviderTrait

### DIFF
--- a/src/DataProvider/AbstractDataProvider.php
+++ b/src/DataProvider/AbstractDataProvider.php
@@ -14,6 +14,7 @@ use Refinery29\Test\Util\Faker\GeneratorTrait;
 abstract class AbstractDataProvider implements DataProviderInterface
 {
     use GeneratorTrait;
+    use DataProviderTrait;
 
     /**
      * @return array
@@ -22,10 +23,6 @@ abstract class AbstractDataProvider implements DataProviderInterface
 
     public function data()
     {
-        foreach ($this->values() as $value) {
-            yield [
-                $value,
-            ];
-        }
+        return $this->provideData($this->values());
     }
 }

--- a/src/DataProvider/DataProviderTrait.php
+++ b/src/DataProvider/DataProviderTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+use Generator;
+
+trait DataProviderTrait
+{
+    /**
+     * @param array $values
+     *
+     * @return Generator
+     */
+    public function provideData(array $values)
+    {
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+}

--- a/test/DataProvider/DataProviderTraitTest.php
+++ b/test/DataProvider/DataProviderTraitTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\DataProviderTrait;
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Traversable;
+
+class DataProviderTraitTest extends \PHPUnit_Framework_TestCase
+{
+    use DataProviderTrait;
+    use GeneratorTrait;
+
+    public function testProvideDataYieldsValues()
+    {
+        $values = $this->getFaker()->words;
+
+        $data = $this->provideData($values);
+
+        $this->assertInstanceOf(Traversable::class, $data);
+
+        $expected = array_map(function ($value) {
+            return [
+                $value,
+            ];
+        }, $values);
+
+        $this->assertSame($expected, iterator_to_array($data));
+    }
+}


### PR DESCRIPTION
This PR

* [x] extracts a `DataProviderTrait`

:information_desk_person: The idea is not having to repeat ourselves too much when we want to make use of data providers.
