### PR TITLE
Fix: Hexadecimal color with Alpha should actually have 4 bytes

### DIFF
--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -18,7 +18,7 @@ class Color
      */
     public static function hexColorWithAlpha()
     {
-        return '#' . str_pad(dechex(mt_rand(1, 4294967295)), 6, '0', STR_PAD_LEFT);
+        return '#' . str_pad(dechex(mt_rand(1, 4294967295)), 8, '0', STR_PAD_LEFT);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] ensures that the `hexColorWithAlpha()` provider always returns 4 bytes instead of 3

Follows #3.

