### PR TITLE
Enhancement: Allow to specify locale when fetching Faker\Generator

### DIFF
--- a/src/Faker/GeneratorTrait.php
+++ b/src/Faker/GeneratorTrait.php
@@ -10,23 +10,32 @@
 namespace Refinery29\Test\Util\Faker;
 
 use Faker\Factory;
+use InvalidArgumentException;
 use Refinery29\Test\Util\Faker\Provider\Color;
 
 trait GeneratorTrait
 {
     /**
+     * @param string $locale
+     *
      * @return Generator
      */
-    protected static function getFaker()
+    protected static function getFaker($locale = 'en_US')
     {
-        static $faker;
+        static $fakers = [];
 
-        if ($faker === null) {
-            $faker = Factory::create('en_US');
-            $faker->addProvider(new Color());
-            $faker->seed(9000);
+        if (!is_string($locale)) {
+            throw new InvalidArgumentException('Locale should be a string');
         }
 
-        return $faker;
+        if (!array_key_exists($locale, $fakers)) {
+            $faker = Factory::create($locale);
+            $faker->addProvider(new Color());
+            $faker->seed(9000);
+
+            $fakers[$locale] = $faker;
+        }
+
+        return $fakers[$locale];
     }
 }

--- a/test/Faker/GeneratorTraitTest.php
+++ b/test/Faker/GeneratorTraitTest.php
@@ -30,11 +30,67 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Faker\Generator', $faker);
     }
 
-    public function testGetFakerReturnsTheSameInstance()
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $locale
+     */
+    public function testGetFakerRejectsInvalidLocale($locale)
     {
-        $faker = $this->getFaker();
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Locale should be a string'
+        );
 
+        $this->getFaker($locale);
+    }
+
+    public function testGetFakerReturnsFakerWithDefaultLocale()
+    {
+        $faker = $this->getFaker('en_US');
+
+        $this->assertInstanceOf('Faker\Generator', $faker);
         $this->assertSame($faker, $this->getFaker());
+    }
+
+    public function testGetFakerReturnsDifferentFakerForDifferentLocale()
+    {
+        $faker = $this->getFaker('en_US');
+
+        $this->assertInstanceOf('Faker\Generator', $faker);
+        $this->assertNotSame($faker, $this->getFaker('de_DE'));
+    }
+
+    /**
+     * @dataProvider providerLocale
+     *
+     * @param string $locale
+     */
+    public function testGetFakerReturnsTheSameInstanceForALocale($locale)
+    {
+        $faker = $this->getFaker($locale);
+
+        $this->assertInstanceOf('Faker\Generator', $faker);
+        $this->assertSame($faker, $this->getFaker($locale));
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerLocale()
+    {
+        $values = [
+            'de_DE',
+            'en_US',
+            'en_UK',
+            'fr_FR',
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] allows to specify a locale when fetching a `Faker\Generator` 
