### PR TITLE
Fix: Do not use assertions to assert invalidity of values

### DIFF
--- a/test/DataProvider/InvalidBooleanTest.php
+++ b/test/DataProvider/InvalidBooleanTest.php
@@ -9,8 +9,6 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
-use InvalidArgumentException;
 use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidBoolean;
 
@@ -30,8 +28,6 @@ class InvalidBooleanTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsNotABoolean($value)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
-
-        Assertion::boolean($value);
+        $this->assertFalse(is_bool($value));
     }
 }

--- a/test/DataProvider/InvalidFloatTest.php
+++ b/test/DataProvider/InvalidFloatTest.php
@@ -9,8 +9,6 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
-use InvalidArgumentException;
 use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidFloat;
 
@@ -30,8 +28,6 @@ class InvalidFloatTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsNotAFloat($value)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
-
-        Assertion::float($value);
+        $this->assertFalse(is_float($value));
     }
 }

--- a/test/DataProvider/InvalidIntegerTest.php
+++ b/test/DataProvider/InvalidIntegerTest.php
@@ -9,8 +9,6 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
-use InvalidArgumentException;
 use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidInteger;
 
@@ -30,8 +28,6 @@ class InvalidIntegerTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsNotAnInteger($value)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
-
-        Assertion::integer($value);
+        $this->assertFalse(is_int($value));
     }
 }

--- a/test/DataProvider/InvalidStringTest.php
+++ b/test/DataProvider/InvalidStringTest.php
@@ -9,8 +9,6 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
-use InvalidArgumentException;
 use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidString;
 
@@ -30,8 +28,6 @@ class InvalidStringTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsNotAString($value)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
-
-        Assertion::string($value);
+        $this->assertFalse(is_string($value));
     }
 }


### PR DESCRIPTION
This PR

* [x] skips using `Assert\Assertion` in tests for data providers, where easily possible 

💁 It's weird, no?!