### PR TITLE
Fix: Require, do not suggest fzaninotto/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,17 +25,16 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.5",
+        "fzaninotto/faker": "^1.6.0"
     },
     "require-dev": {
         "beberlei/assert": "^2.5.0",
         "codeclimate/php-test-reporter": "0.2.0",
-        "fzaninotto/faker": "^1.6.0",
         "phpunit/phpunit": "^4.8.18 || ^5.2.3",
         "refinery29/php-cs-fixer-config": "0.4.11"
     },
     "suggest": {
-        "fzaninotto/faker": "If you want to make use of the Faker\\GeneratorTrait",
         "phpunit/phpunit": "If you want to make use of the PHPUnit\\BuildsMocksTrait"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,58 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b9cd1b26e7d6f50c1d197352e09291fb",
-    "content-hash": "f3395dc54d9e68c55bba72f8e6a12a1b",
-    "packages": [],
+    "hash": "5159b2a18ee9c4ee7fd3daa897c25b95",
+    "content-hash": "fab823d649cb920191f24801311653aa",
+    "packages": [
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2016-04-29 12:21:54"
+        }
+    ],
     "packages-dev": [
         {
             "name": "beberlei/assert",
@@ -232,54 +281,6 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "time": "2016-04-28 21:56:27"
-        },
-        {
-            "name": "fzaninotto/faker",
-            "version": "v1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3|^7.0"
-            },
-            "require-dev": {
-                "ext-intl": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": []
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "time": "2016-04-29 12:21:54"
         },
         {
             "name": "guzzle/guzzle",


### PR DESCRIPTION
This PR

* [x] requires `fzaninotto/faker` instead of suggesting it only

💁 Without it, the data providers do not work.