### PR TITLE
Fix: Use expectedException() instead of deprecated setExpectedException()

### DIFF
--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -30,7 +30,7 @@ class InvalidUrlTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsNotAUrl($value)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Assertion::url($value);
     }

--- a/test/DataProvider/InvalidUuidTest.php
+++ b/test/DataProvider/InvalidUuidTest.php
@@ -30,7 +30,7 @@ class InvalidUuidTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsNotAUuid($value)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         Assertion::string($value);
         Assertion::uuid($value);

--- a/test/Faker/GeneratorTraitTest.php
+++ b/test/Faker/GeneratorTraitTest.php
@@ -37,7 +37,7 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetFakerRejectsInvalidLocale($locale)
     {
-        $this->setExpectedException(
+        $this->expectException(
             'InvalidArgumentException',
             'Locale should be a string'
         );


### PR DESCRIPTION
This PR

* [x] uses `expectException()` instead of the deprecated `setExpectedException()`

Follows #53.