### PR TITLE
Fix: Remove suggestion in regard to BuildsMocksTrait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,6 @@
         "phpunit/phpunit": "^5.4.2",
         "refinery29/php-cs-fixer-config": "0.4.16"
     },
-    "suggest": {
-        "phpunit/phpunit": "If you want to make use of the PHPUnit\\BuildsMocksTrait"
-    },
     "autoload": {
         "psr-4": {
             "Refinery29\\Test\\Util\\": "src"


### PR DESCRIPTION
This PR

* [x] removes a suggestion that doesn't make sense anymore 

Follows #54.