### PR TITLE
Enhancement: Create variations of data providers which do not provide null

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,22 @@ of the data providers:
 
 * `Refinery29\Test\Util\DataProvider\BlankString`
 * `Refinery29\Test\Util\DataProvider\InvalidBoolean`
+* `Refinery29\Test\Util\DataProvider\InvalidBooleanNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidFloat`
+* `Refinery29\Test\Util\DataProvider\InvalidFloatNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidInteger`
+* `Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull`
+* `Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidNumeric`
+* `Refinery29\Test\Util\DataProvider\InvalidNumericNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidScalar`
+* `Refinery29\Test\Util\DataProvider\InvalidScalarNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidString`
+* `Refinery29\Test\Util\DataProvider\InvalidStringNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidUrl`
+* `Refinery29\Test\Util\DataProvider\InvalidUrlNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidUuid`
+* `Refinery29\Test\Util\DataProvider\InvalidUuidNotNull`
 
 ```php
 namespace Foo\Bar\Test;

--- a/src/DataProvider/InvalidBooleanNotNull.php
+++ b/src/DataProvider/InvalidBooleanNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidBooleanNotNull extends InvalidBoolean
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/InvalidFloatNotNull.php
+++ b/src/DataProvider/InvalidFloatNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidFloatNotNull extends InvalidFloat
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/InvalidIntegerNotNull.php
+++ b/src/DataProvider/InvalidIntegerNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidIntegerNotNull extends InvalidInteger
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/InvalidNumericNotNull.php
+++ b/src/DataProvider/InvalidNumericNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidNumericNotNull extends InvalidNumeric
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/InvalidScalarNotNull.php
+++ b/src/DataProvider/InvalidScalarNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidScalarNotNull extends InvalidScalar
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/InvalidStringNotNull.php
+++ b/src/DataProvider/InvalidStringNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidStringNotNull extends InvalidString
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/InvalidUrlNotNull.php
+++ b/src/DataProvider/InvalidUrlNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidUrlNotNull extends InvalidUrl
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/InvalidUuidNotNull.php
+++ b/src/DataProvider/InvalidUuidNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidUuidNotNull extends InvalidUuid
+{
+    use NotNull;
+
+    public function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/src/DataProvider/NotNull.php
+++ b/src/DataProvider/NotNull.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+/**
+ * @internal
+ */
+trait NotNull
+{
+    /**
+     * @param array $values
+     *
+     * @return array
+     */
+    public function notNull(array $values)
+    {
+        return array_filter($values, function ($value) {
+            return $value !== null;
+        });
+    }
+}

--- a/test/DataProvider/InvalidBooleanNotNullTest.php
+++ b/test/DataProvider/InvalidBooleanNotNullTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\InvalidBooleanNotNull;
+
+class InvalidBooleanNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    protected function className()
+    {
+        return InvalidBooleanNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBooleanNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotABoolean($value)
+    {
+        $this->assertFalse(is_bool($value));
+    }
+}

--- a/test/DataProvider/InvalidFloatNotNullTest.php
+++ b/test/DataProvider/InvalidFloatNotNullTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\InvalidFloatNotNull;
+
+class InvalidFloatNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    protected function className()
+    {
+        return InvalidFloatNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidFloatNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAFloat($value)
+    {
+        $this->assertFalse(is_float($value));
+    }
+}

--- a/test/DataProvider/InvalidIntegerNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerNotNullTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull;
+
+class InvalidIntegerNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    public function className()
+    {
+        return InvalidIntegerNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAnInteger($value)
+    {
+        $this->assertFalse(is_int($value));
+    }
+}

--- a/test/DataProvider/InvalidNumericNotNullTest.php
+++ b/test/DataProvider/InvalidNumericNotNullTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\InvalidNumericNotNull;
+
+class InvalidNumericNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    public function className()
+    {
+        return InvalidNumericNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidNumericNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotNumeric($value)
+    {
+        $this->assertFalse(is_numeric($value));
+    }
+}

--- a/test/DataProvider/InvalidScalarNotNullTest.php
+++ b/test/DataProvider/InvalidScalarNotNullTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\InvalidScalarNotNull;
+
+class InvalidScalarNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    protected function className()
+    {
+        return InvalidScalarNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidScalarNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAScalar($value)
+    {
+        $this->assertFalse(is_scalar($value));
+    }
+}

--- a/test/DataProvider/InvalidStringNotNullTest.php
+++ b/test/DataProvider/InvalidStringNotNullTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\InvalidStringNotNull;
+
+class InvalidStringNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    protected function className()
+    {
+        return InvalidStringNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidStringNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAString($value)
+    {
+        $this->assertFalse(is_string($value));
+    }
+}

--- a/test/DataProvider/InvalidUrlNotNullTest.php
+++ b/test/DataProvider/InvalidUrlNotNullTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Assert\Assertion;
+use Refinery29\Test\Util\DataProvider\InvalidUrlNotNull;
+
+class InvalidUrlNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    protected function className()
+    {
+        return InvalidUrlNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrlNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAUrl($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Assertion::nullOrUrl($value);
+    }
+}

--- a/test/DataProvider/InvalidUuidNotNullTest.php
+++ b/test/DataProvider/InvalidUuidNotNullTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Assert\Assertion;
+use Refinery29\Test\Util\DataProvider\InvalidUuidNotNull;
+
+class InvalidUuidNotNullTest extends AbstractDataProviderTestCase
+{
+    use NotNull;
+
+    protected function className()
+    {
+        return InvalidUuidNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUuidNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAUuid($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Assertion::nullOrString($value);
+        Assertion::nullOrUuid($value);
+    }
+}

--- a/test/DataProvider/NotNull.php
+++ b/test/DataProvider/NotNull.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+/**
+ * @internal
+ */
+trait NotNull
+{
+    final public function testDoesNotProvideNull()
+    {
+        $reflection = new \ReflectionClass($this->className());
+
+        $dataProvider = $reflection->newInstance();
+
+        $this->assertNotContains(null, $dataProvider->data());
+    }
+}


### PR DESCRIPTION
This PR

* [x] Adds "invalid" Data Providers that do not provide `null`
* [x] Intended to be used for methods that allow a scalar type and `null`


```
/**
 * @param string|null $value
 */
function foo($value)
{
    Assertion::nullOrString($value);
    // does something
}

/**
 * @dataProvider Refinery29\Test\Util\DataProvider\InvalidStringWithoutNull::data()
 * 
 * @param mixed $value
 */
public function testFoo($value)
{
    $this->expectException(\InvalidArgumentException::class);
    foo($value);
}
```