### PR TITLE
Fix: Extract AbstractDataProviderTestCase

### DIFF
--- a/test/DataProvider/AbstractDataProviderTestCase.php
+++ b/test/DataProvider/AbstractDataProviderTestCase.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Refinery29\Test\Util\DataProvider\DataProviderInterface;
+
+abstract class AbstractDataProviderTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return string
+     */
+    abstract protected function className();
+
+    final public function testImplementsDataProviderInterface()
+    {
+        $reflection = new \ReflectionClass($this->className());
+
+        $this->assertTrue($reflection->implementsInterface(DataProviderInterface::class));
+    }
+}

--- a/test/DataProvider/BlankStringTest.php
+++ b/test/DataProvider/BlankStringTest.php
@@ -10,15 +10,12 @@
 namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\BlankString;
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 
-class BlankStringTest extends \PHPUnit_Framework_TestCase
+class BlankStringTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new BlankString();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return BlankString::class;
     }
 
     /**

--- a/test/DataProvider/InvalidBooleanTest.php
+++ b/test/DataProvider/InvalidBooleanTest.php
@@ -9,16 +9,13 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidBoolean;
 
-class InvalidBooleanTest extends \PHPUnit_Framework_TestCase
+class InvalidBooleanTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidBoolean();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidBoolean::class;
     }
 
     /**

--- a/test/DataProvider/InvalidFloatTest.php
+++ b/test/DataProvider/InvalidFloatTest.php
@@ -9,16 +9,13 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidFloat;
 
-class InvalidFloatTest extends \PHPUnit_Framework_TestCase
+class InvalidFloatTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidFloat();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidFloat::class;
     }
 
     /**

--- a/test/DataProvider/InvalidIntegerTest.php
+++ b/test/DataProvider/InvalidIntegerTest.php
@@ -9,16 +9,13 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidInteger;
 
-class InvalidIntegerTest extends \PHPUnit_Framework_TestCase
+class InvalidIntegerTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidInteger();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidInteger::class;
     }
 
     /**

--- a/test/DataProvider/InvalidNumericTest.php
+++ b/test/DataProvider/InvalidNumericTest.php
@@ -9,16 +9,13 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidNumeric;
 
-class InvalidNumericTest extends \PHPUnit_Framework_TestCase
+class InvalidNumericTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidNumeric();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidNumeric::class;
     }
 
     /**

--- a/test/DataProvider/InvalidScalarTest.php
+++ b/test/DataProvider/InvalidScalarTest.php
@@ -9,16 +9,13 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidScalar;
 
-class InvalidScalarTest extends \PHPUnit_Framework_TestCase
+class InvalidScalarTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidScalar();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidScalar::class;
     }
 
     /**

--- a/test/DataProvider/InvalidStringTest.php
+++ b/test/DataProvider/InvalidStringTest.php
@@ -9,16 +9,13 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidString;
 
-class InvalidStringTest extends \PHPUnit_Framework_TestCase
+class InvalidStringTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidString();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidString::class;
     }
 
     /**

--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -10,16 +10,13 @@
 namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Assert\Assertion;
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidUrl;
 
-class InvalidUrlTest extends \PHPUnit_Framework_TestCase
+class InvalidUrlTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidUrl();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidUrl::class;
     }
 
     /**

--- a/test/DataProvider/InvalidUuidTest.php
+++ b/test/DataProvider/InvalidUuidTest.php
@@ -10,16 +10,13 @@
 namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Assert\Assertion;
-use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\DataProvider\InvalidUuid;
 
-class InvalidUuidTest extends \PHPUnit_Framework_TestCase
+class InvalidUuidTest extends AbstractDataProviderTestCase
 {
-    public function testImplementsDataProviderInterface()
+    protected function className()
     {
-        $dataProvider = new InvalidUuid();
-
-        $this->assertInstanceOf(DataProviderInterface::class, $dataProvider);
+        return InvalidUuid::class;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] extracts an `AbstractDataProviderTestCase`

Related to #64.

💁 This should help with the tests for the PR referenced above.
