### PR TITLE
Enhancement: Add InvalidIsoDate data provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ of the data providers:
 * `Refinery29\Test\Util\DataProvider\InvalidFloatNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidInteger`
 * `Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull`
-* `Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull`
+* `Refinery29\Test\Util\DataProvider\InvalidIsoDate`
+* `Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidNumeric`
 * `Refinery29\Test\Util\DataProvider\InvalidNumericNotNull`
 * `Refinery29\Test\Util\DataProvider\InvalidScalar`

--- a/src/DataProvider/InvalidIsoDate.php
+++ b/src/DataProvider/InvalidIsoDate.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+use Refinery29\Test\Util\Faker\GeneratorTrait;
+
+class InvalidIsoDate extends InvalidString
+{
+    use GeneratorTrait;
+
+    protected function values()
+    {
+        $faker = $this->getFaker();
+
+        $date = $faker->dateTime;
+
+        return array_merge(parent::values(), [
+            $faker->word,
+            $date->format(DATE_ATOM),
+            $date->format(DATE_COOKIE),
+            $date->format(DATE_RFC822),
+            $date->format(DATE_RFC850),
+            $date->format(DATE_RFC1036),
+            $date->format(DATE_RFC1123),
+            $date->format(DATE_RFC2822),
+            $date->format(DATE_RFC3339),
+            $date->format(DATE_RSS),
+            $date->format(DATE_W3C),
+        ]);
+    }
+}

--- a/src/DataProvider/InvalidIsoDateNotNull.php
+++ b/src/DataProvider/InvalidIsoDateNotNull.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\DataProvider;
+
+class InvalidIsoDateNotNull extends InvalidIsoDate
+{
+    use NotNull;
+
+    protected function values()
+    {
+        return $this->notNull(parent::values());
+    }
+}

--- a/test/DataProvider/InvalidIsoDateNotNullTest.php
+++ b/test/DataProvider/InvalidIsoDateNotNullTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Assert\Assertion;
+use Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull;
+
+class InvalidIsoDateNotNullTest extends AbstractDataProviderTestCase
+{
+    protected function className()
+    {
+        return InvalidIsoDateNotNull::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAnIsoDate($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Assertion::string($value);
+        Assertion::date($value, DATE_ISO8601);
+    }
+}

--- a/test/DataProvider/InvalidIsoDateTest.php
+++ b/test/DataProvider/InvalidIsoDateTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\DataProvider;
+
+use Assert\Assertion;
+use Refinery29\Test\Util\DataProvider\InvalidIsoDate;
+
+class InvalidIsoDateTest extends AbstractDataProviderTestCase
+{
+    protected function className()
+    {
+        return InvalidIsoDate::class;
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidIsoDate::data()
+     *
+     * @param mixed $value
+     */
+    public function testIsNotAnIsoDate($value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Assertion::string($value);
+        Assertion::date($value, DATE_ISO8601);
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `InvalidIsoDate` provider

Following: https://github.com/refinery29/zeppelin/pull/885/files#r72115858