### PR TITLE
Fix: Mark data() as final

### DIFF
--- a/src/DataProvider/AbstractDataProvider.php
+++ b/src/DataProvider/AbstractDataProvider.php
@@ -21,7 +21,7 @@ abstract class AbstractDataProvider implements DataProviderInterface
      */
     abstract protected function values();
 
-    public function data()
+    final public function data()
     {
         return $this->provideData($this->values());
     }


### PR DESCRIPTION
This PR

* [x] marks `AbstractDataProvider::data()` as `final` to make it obvious that it should not be overridden

