### PR TITLE
Bugfix: Switch to DATE_ATOM

### DIFF
--- a/src/DataProvider/InvalidIsoDate.php
+++ b/src/DataProvider/InvalidIsoDate.php
@@ -23,16 +23,14 @@ class InvalidIsoDate extends InvalidString
 
         return array_merge(parent::values(), [
             $faker->word,
-            $date->format(DATE_ATOM),
+            $date->format(DATE_ISO8601),
             $date->format(DATE_COOKIE),
             $date->format(DATE_RFC822),
             $date->format(DATE_RFC850),
             $date->format(DATE_RFC1036),
             $date->format(DATE_RFC1123),
             $date->format(DATE_RFC2822),
-            $date->format(DATE_RFC3339),
             $date->format(DATE_RSS),
-            $date->format(DATE_W3C),
         ]);
     }
 }

--- a/test/DataProvider/InvalidIsoDateNotNullTest.php
+++ b/test/DataProvider/InvalidIsoDateNotNullTest.php
@@ -29,6 +29,6 @@ class InvalidIsoDateNotNullTest extends AbstractDataProviderTestCase
         $this->expectException(\InvalidArgumentException::class);
 
         Assertion::string($value);
-        Assertion::date($value, DATE_ISO8601);
+        Assertion::date($value, DATE_ATOM);
     }
 }

--- a/test/DataProvider/InvalidIsoDateTest.php
+++ b/test/DataProvider/InvalidIsoDateTest.php
@@ -29,6 +29,6 @@ class InvalidIsoDateTest extends AbstractDataProviderTestCase
         $this->expectException(\InvalidArgumentException::class);
 
         Assertion::string($value);
-        Assertion::date($value, DATE_ISO8601);
+        Assertion::date($value, DATE_ATOM);
     }
 }


### PR DESCRIPTION
This PR

* [x] Changes DATE_ISO8601 to DATE_ATOM

See: http://php.net/manual/en/class.datetime.php

```
Note: This format is not compatible with ISO-8601, but is left this way for backward compatibility reasons. Use DateTime::ATOM or DATE_ATOM for compatibility with ISO-8601 instead.
```
