### PR TITLE
Fix: Reduce visibility of provideData from public to protected

### DIFF
--- a/src/DataProvider/DataProviderTrait.php
+++ b/src/DataProvider/DataProviderTrait.php
@@ -16,7 +16,7 @@ trait DataProviderTrait
      *
      * @return \Generator
      */
-    public function provideData(array $values)
+    protected function provideData(array $values)
     {
         foreach ($values as $value) {
             yield [


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `DataProvider::provideData()` from `public` to `protected`

💁 The intention of the trait is to be used from *within* the context of a test case, so reducing the visibility should not break any tests, but reduce the API.

