### PR TITLE
Fix: Prepend slash when referencing data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ use Foo\Bar\Baz;
 class BazTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
      * 
      * @param mixed $name
      */

--- a/test/DataProvider/BlankStringTest.php
+++ b/test/DataProvider/BlankStringTest.php
@@ -19,7 +19,7 @@ class BlankStringTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\BlankString::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/BooleanTest.php
+++ b/test/DataProvider/BooleanTest.php
@@ -19,7 +19,7 @@ class BooleanTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\Boolean::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\Boolean::data()
      *
      * @param bool $value
      */

--- a/test/DataProvider/InvalidBooleanNotNullTest.php
+++ b/test/DataProvider/InvalidBooleanNotNullTest.php
@@ -21,7 +21,7 @@ class InvalidBooleanNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBooleanNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidBooleanNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidBooleanTest.php
+++ b/test/DataProvider/InvalidBooleanTest.php
@@ -19,7 +19,7 @@ class InvalidBooleanTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidFloatNotNullTest.php
+++ b/test/DataProvider/InvalidFloatNotNullTest.php
@@ -21,7 +21,7 @@ class InvalidFloatNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidFloatNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidFloatNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidFloatTest.php
+++ b/test/DataProvider/InvalidFloatTest.php
@@ -19,7 +19,7 @@ class InvalidFloatTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidFloat::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidFloat::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidIntegerNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerNotNullTest.php
@@ -21,7 +21,7 @@ class InvalidIntegerNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidIntegerTest.php
+++ b/test/DataProvider/InvalidIntegerTest.php
@@ -19,7 +19,7 @@ class InvalidIntegerTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidInteger::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidInteger::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidIsoDateNotNullTest.php
+++ b/test/DataProvider/InvalidIsoDateNotNullTest.php
@@ -20,7 +20,7 @@ class InvalidIsoDateNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidIsoDateTest.php
+++ b/test/DataProvider/InvalidIsoDateTest.php
@@ -20,7 +20,7 @@ class InvalidIsoDateTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidIsoDate::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidIsoDate::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidNumericNotNullTest.php
+++ b/test/DataProvider/InvalidNumericNotNullTest.php
@@ -21,7 +21,7 @@ class InvalidNumericNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidNumericNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidNumericNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidNumericTest.php
+++ b/test/DataProvider/InvalidNumericTest.php
@@ -19,7 +19,7 @@ class InvalidNumericTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidNumeric::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidNumeric::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidScalarNotNullTest.php
+++ b/test/DataProvider/InvalidScalarNotNullTest.php
@@ -21,7 +21,7 @@ class InvalidScalarNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidScalarNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidScalarNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidScalarTest.php
+++ b/test/DataProvider/InvalidScalarTest.php
@@ -19,7 +19,7 @@ class InvalidScalarTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidScalar::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidScalar::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidStringNotNullTest.php
+++ b/test/DataProvider/InvalidStringNotNullTest.php
@@ -21,7 +21,7 @@ class InvalidStringNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidStringNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidStringNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidStringTest.php
+++ b/test/DataProvider/InvalidStringTest.php
@@ -19,7 +19,7 @@ class InvalidStringTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidUrlNotNullTest.php
+++ b/test/DataProvider/InvalidUrlNotNullTest.php
@@ -22,7 +22,7 @@ class InvalidUrlNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrlNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidUrlNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -20,7 +20,7 @@ class InvalidUrlTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUrl::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidUrl::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidUuidNotNullTest.php
+++ b/test/DataProvider/InvalidUuidNotNullTest.php
@@ -22,7 +22,7 @@ class InvalidUuidNotNullTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUuidNotNull::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidUuidNotNull::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/InvalidUuidTest.php
+++ b/test/DataProvider/InvalidUuidTest.php
@@ -20,7 +20,7 @@ class InvalidUuidTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidUuid::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidUuid::data()
      *
      * @param mixed $value
      */

--- a/test/DataProvider/ScalarTest.php
+++ b/test/DataProvider/ScalarTest.php
@@ -19,7 +19,7 @@ class ScalarTest extends AbstractDataProviderTestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\Scalar::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\Scalar::data()
      *
      * @param mixed $value
      */

--- a/test/Faker/GeneratorTraitTest.php
+++ b/test/Faker/GeneratorTraitTest.php
@@ -32,7 +32,7 @@ class GeneratorTraitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
      * @param mixed $locale
      */


### PR DESCRIPTION
This PR

* [x] prepends a `\` when referencing data providers

💁 `phpunit/phpunit` doesn't seem to care, but PHPStorm complains.
