### PR TITLE
Fix: Make values() part of the DataProviderInterface

### DIFF
--- a/src/DataProvider/AbstractDataProvider.php
+++ b/src/DataProvider/AbstractDataProvider.php
@@ -16,11 +16,6 @@ abstract class AbstractDataProvider implements DataProviderInterface
     use GeneratorTrait;
     use DataProviderTrait;
 
-    /**
-     * @return array
-     */
-    abstract protected function values();
-
     final public function data()
     {
         return $this->provideData($this->values());

--- a/src/DataProvider/BlankString.php
+++ b/src/DataProvider/BlankString.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class BlankString extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         return [
             '',

--- a/src/DataProvider/Boolean.php
+++ b/src/DataProvider/Boolean.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class Boolean extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         return [
             true,

--- a/src/DataProvider/DataProviderInterface.php
+++ b/src/DataProvider/DataProviderInterface.php
@@ -12,10 +12,9 @@ namespace Refinery29\Test\Util\DataProvider;
 interface DataProviderInterface
 {
     /**
-     * This method should return an array or a Traversable, iterating over which should return an array of arguments to
-     * pass to a test method that makes use of the concrete data provider.
+     * This method should return an array or a Traversable.
      *
      * @return array|\Traversable
      */
-    public function data();
+    public function values();
 }

--- a/src/DataProvider/InvalidBoolean.php
+++ b/src/DataProvider/InvalidBoolean.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class InvalidBoolean extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidBooleanNotNull.php
+++ b/src/DataProvider/InvalidBooleanNotNull.php
@@ -13,7 +13,7 @@ class InvalidBooleanNotNull extends InvalidBoolean
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/InvalidFloat.php
+++ b/src/DataProvider/InvalidFloat.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class InvalidFloat extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidFloatNotNull.php
+++ b/src/DataProvider/InvalidFloatNotNull.php
@@ -13,7 +13,7 @@ class InvalidFloatNotNull extends InvalidFloat
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/InvalidInteger.php
+++ b/src/DataProvider/InvalidInteger.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class InvalidInteger extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidIntegerNotNull.php
+++ b/src/DataProvider/InvalidIntegerNotNull.php
@@ -13,7 +13,7 @@ class InvalidIntegerNotNull extends InvalidInteger
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/InvalidIsoDate.php
+++ b/src/DataProvider/InvalidIsoDate.php
@@ -15,7 +15,7 @@ class InvalidIsoDate extends InvalidString
 {
     use GeneratorTrait;
 
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidIsoDateNotNull.php
+++ b/src/DataProvider/InvalidIsoDateNotNull.php
@@ -13,7 +13,7 @@ class InvalidIsoDateNotNull extends InvalidIsoDate
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/InvalidNumeric.php
+++ b/src/DataProvider/InvalidNumeric.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class InvalidNumeric extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidNumericNotNull.php
+++ b/src/DataProvider/InvalidNumericNotNull.php
@@ -13,7 +13,7 @@ class InvalidNumericNotNull extends InvalidNumeric
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/InvalidScalar.php
+++ b/src/DataProvider/InvalidScalar.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class InvalidScalar extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidScalarNotNull.php
+++ b/src/DataProvider/InvalidScalarNotNull.php
@@ -13,7 +13,7 @@ class InvalidScalarNotNull extends InvalidScalar
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/InvalidString.php
+++ b/src/DataProvider/InvalidString.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class InvalidString extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidStringNotNull.php
+++ b/src/DataProvider/InvalidStringNotNull.php
@@ -13,7 +13,7 @@ class InvalidStringNotNull extends InvalidString
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/InvalidUrl.php
+++ b/src/DataProvider/InvalidUrl.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class InvalidUrl extends InvalidString
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 

--- a/src/DataProvider/InvalidUrlNotNull.php
+++ b/src/DataProvider/InvalidUrlNotNull.php
@@ -13,7 +13,7 @@ class InvalidUrlNotNull extends InvalidUrl
 {
     use NotNull;
 
-    protected function values()
+    public function values()
     {
         return $this->notNull(parent::values());
     }

--- a/src/DataProvider/Scalar.php
+++ b/src/DataProvider/Scalar.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\DataProvider;
 
 class Scalar extends AbstractDataProvider
 {
-    protected function values()
+    public function values()
     {
         $faker = $this->getFaker();
 


### PR DESCRIPTION
This PR

* [x] makes `values()` part of the `DataProviderInterface`, and drops `data()`

💁 The method `data()` is still provided by `AbstractDataProvider`, and the idea of exposing `values()` is to make it easier to compose data providers.