### PR TITLE
Enhancement: Yield value with associated key

### DIFF
--- a/src/DataProvider/DataProviderTrait.php
+++ b/src/DataProvider/DataProviderTrait.php
@@ -18,9 +18,9 @@ trait DataProviderTrait
      */
     protected function provideData(array $values)
     {
-        foreach ($values as $value) {
+        foreach ($values as $key => $value) {
             yield [
-                $value,
+                $key => $value,
             ];
         }
     }

--- a/test/DataProvider/DataProviderTraitTest.php
+++ b/test/DataProvider/DataProviderTraitTest.php
@@ -19,17 +19,22 @@ class DataProviderTraitTest extends \PHPUnit_Framework_TestCase
 
     public function testProvideDataYieldsValues()
     {
-        $values = $this->getFaker()->words;
+        $faker = $this->getFaker();
+
+        $values = array_combine(
+            $faker->unique()->words(5),
+            $faker->unique()->words(5)
+        );
 
         $data = $this->provideData($values);
 
         $this->assertInstanceOf(\Traversable::class, $data);
 
-        $expected = array_map(function ($value) {
+        $expected = array_map(function ($value, $key) {
             return [
-                $value,
+                $key => $value,
             ];
-        }, $values);
+        }, array_values($values), array_keys($values));
 
         $this->assertSame($expected, iterator_to_array($data));
     }


### PR DESCRIPTION
This PR

* [x] yields values provided by a  data provider along with their associated keys

💁 This allows to specify keys, which in turn could be helpful when tests fail.
