### PR TITLE
Bugfix: Fix incorrect doc block

### DIFF
--- a/src/DataProvider/DataProviderTrait.php
+++ b/src/DataProvider/DataProviderTrait.php
@@ -10,7 +10,7 @@
 namespace Refinery29\Test\Util\DataProvider;
 
 /**
- * @deprecated Use TestTrait instead.
+ * @deprecated Use Refinery29\Test\Util\TestHelper instead.
  */
 trait DataProviderTrait
 {

--- a/src/Faker/GeneratorTrait.php
+++ b/src/Faker/GeneratorTrait.php
@@ -13,7 +13,7 @@ use Faker\Factory;
 use Refinery29\Test\Util\Faker\Provider\Color;
 
 /**
- * @deprecated Use TestTrait instead.
+ * @deprecated Use Refinery29\Test\Util\TestHelper instead.
  */
 trait GeneratorTrait
 {


### PR DESCRIPTION
This PR

* [x] updates the `@deprecated` docblock to point to the right trait