### PR TITLE
Fix: Use false and true

### DIFF
--- a/src/DataProvider/InvalidFloat.php
+++ b/src/DataProvider/InvalidFloat.php
@@ -17,7 +17,8 @@ class InvalidFloat extends AbstractDataProvider
 
         return [
             'null' => null,
-            'boolean' => $faker->boolean(),
+            'boolean-true' => true,
+            'boolean-false' => false,
             'integer' => $faker->randomNumber(),
             'float-casted-to-string' => (string) $faker->randomFloat(1),
             'string' => $faker->word,

--- a/src/DataProvider/InvalidInteger.php
+++ b/src/DataProvider/InvalidInteger.php
@@ -17,7 +17,8 @@ class InvalidInteger extends AbstractDataProvider
 
         return [
             'null' => null,
-            'boolean' => $faker->boolean(),
+            'boolean-true' => true,
+            'boolean-false' => false,
             'float' => $faker->randomFloat(),
             'integer-casted-to-string' => (string) $faker->randomNumber(),
             'string' => $faker->word,

--- a/src/DataProvider/InvalidString.php
+++ b/src/DataProvider/InvalidString.php
@@ -17,7 +17,8 @@ class InvalidString extends AbstractDataProvider
 
         return [
             'null' => null,
-            'boolean' => $faker->boolean(),
+            'boolean-true' => true,
+            'boolean-false' => false,
             'float' => $faker->randomFloat(),
             'integer' => $faker->randomNumber(),
             'array' => $faker->words,

--- a/src/DataProvider/Scalar.php
+++ b/src/DataProvider/Scalar.php
@@ -16,7 +16,8 @@ class Scalar extends AbstractDataProvider
         $faker = $this->getFaker();
 
         return [
-            'boolean' => $faker->boolean(),
+            'boolean-true' => true,
+            'boolean-false' => false,
             'float' => $faker->randomFloat(),
             'integer' => $faker->randomNumber(),
             'string' => $faker->word,


### PR DESCRIPTION
This PR

* [x] uses `false` and `true` instead _one_ random boolean
