### PR TITLE
Fix: Remove confusing NotNull trait from tests

### DIFF
--- a/test/DataProvider/AbstractNotNullTestCase.php
+++ b/test/DataProvider/AbstractNotNullTestCase.php
@@ -9,10 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-/**
- * @internal
- */
-trait NotNull
+abstract class AbstractNotNullTestCase extends AbstractTestCase
 {
     final public function testDoesNotProvideNull()
     {

--- a/test/DataProvider/AbstractTestCase.php
+++ b/test/DataProvider/AbstractTestCase.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\TestHelper;
 
-abstract class AbstractDataProviderTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/DataProvider/BlankStringTest.php
+++ b/test/DataProvider/BlankStringTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\BlankString;
 
-class BlankStringTest extends AbstractDataProviderTestCase
+class BlankStringTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/BooleanTest.php
+++ b/test/DataProvider/BooleanTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\Boolean;
 
-class BooleanTest extends AbstractDataProviderTestCase
+class BooleanTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/ElementsTest.php
+++ b/test/DataProvider/ElementsTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\Elements;
 
-class ElementsTest extends AbstractDataProviderTestCase
+class ElementsTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidBooleanNotNullTest.php
+++ b/test/DataProvider/InvalidBooleanNotNullTest.php
@@ -11,10 +11,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidBooleanNotNull;
 
-class InvalidBooleanNotNullTest extends AbstractDataProviderTestCase
+class InvalidBooleanNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     protected function className()
     {
         return InvalidBooleanNotNull::class;

--- a/test/DataProvider/InvalidBooleanTest.php
+++ b/test/DataProvider/InvalidBooleanTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidBoolean;
 
-class InvalidBooleanTest extends AbstractDataProviderTestCase
+class InvalidBooleanTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidFloatNotNullTest.php
+++ b/test/DataProvider/InvalidFloatNotNullTest.php
@@ -11,10 +11,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidFloatNotNull;
 
-class InvalidFloatNotNullTest extends AbstractDataProviderTestCase
+class InvalidFloatNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     protected function className()
     {
         return InvalidFloatNotNull::class;

--- a/test/DataProvider/InvalidFloatTest.php
+++ b/test/DataProvider/InvalidFloatTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidFloat;
 
-class InvalidFloatTest extends AbstractDataProviderTestCase
+class InvalidFloatTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIntegerNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerNotNullTest.php
@@ -11,10 +11,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull;
 
-class InvalidIntegerNotNullTest extends AbstractDataProviderTestCase
+class InvalidIntegerNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     public function className()
     {
         return InvalidIntegerNotNull::class;

--- a/test/DataProvider/InvalidIntegerTest.php
+++ b/test/DataProvider/InvalidIntegerTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidInteger;
 
-class InvalidIntegerTest extends AbstractDataProviderTestCase
+class InvalidIntegerTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIntegerishNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerishNotNullTest.php
@@ -12,10 +12,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIntegerishNotNull;
 
-class InvalidIntegerishNotNullTest extends AbstractDataProviderTestCase
+class InvalidIntegerishNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     public function className()
     {
         return InvalidIntegerishNotNull::class;

--- a/test/DataProvider/InvalidIntegerishTest.php
+++ b/test/DataProvider/InvalidIntegerishTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIntegerish;
 
-class InvalidIntegerishTest extends AbstractDataProviderTestCase
+class InvalidIntegerishTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIsoDateNotNullTest.php
+++ b/test/DataProvider/InvalidIsoDateNotNullTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull;
 
-class InvalidIsoDateNotNullTest extends AbstractDataProviderTestCase
+class InvalidIsoDateNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIsoDateTest.php
+++ b/test/DataProvider/InvalidIsoDateTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIsoDate;
 
-class InvalidIsoDateTest extends AbstractDataProviderTestCase
+class InvalidIsoDateTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidNumericNotNullTest.php
+++ b/test/DataProvider/InvalidNumericNotNullTest.php
@@ -11,10 +11,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidNumericNotNull;
 
-class InvalidNumericNotNullTest extends AbstractDataProviderTestCase
+class InvalidNumericNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     public function className()
     {
         return InvalidNumericNotNull::class;

--- a/test/DataProvider/InvalidNumericTest.php
+++ b/test/DataProvider/InvalidNumericTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidNumeric;
 
-class InvalidNumericTest extends AbstractDataProviderTestCase
+class InvalidNumericTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidScalarNotNullTest.php
+++ b/test/DataProvider/InvalidScalarNotNullTest.php
@@ -11,10 +11,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidScalarNotNull;
 
-class InvalidScalarNotNullTest extends AbstractDataProviderTestCase
+class InvalidScalarNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     protected function className()
     {
         return InvalidScalarNotNull::class;

--- a/test/DataProvider/InvalidScalarTest.php
+++ b/test/DataProvider/InvalidScalarTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidScalar;
 
-class InvalidScalarTest extends AbstractDataProviderTestCase
+class InvalidScalarTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidStringNotNullTest.php
+++ b/test/DataProvider/InvalidStringNotNullTest.php
@@ -11,10 +11,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidStringNotNull;
 
-class InvalidStringNotNullTest extends AbstractDataProviderTestCase
+class InvalidStringNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     protected function className()
     {
         return InvalidStringNotNull::class;

--- a/test/DataProvider/InvalidStringTest.php
+++ b/test/DataProvider/InvalidStringTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidString;
 
-class InvalidStringTest extends AbstractDataProviderTestCase
+class InvalidStringTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidUrlNotNullTest.php
+++ b/test/DataProvider/InvalidUrlNotNullTest.php
@@ -12,10 +12,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUrlNotNull;
 
-class InvalidUrlNotNullTest extends AbstractDataProviderTestCase
+class InvalidUrlNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     protected function className()
     {
         return InvalidUrlNotNull::class;
@@ -30,6 +28,6 @@ class InvalidUrlNotNullTest extends AbstractDataProviderTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::nullOrUrl($value);
+        Assertion::url($value);
     }
 }

--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUrl;
 
-class InvalidUrlTest extends AbstractDataProviderTestCase
+class InvalidUrlTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidUuidNotNullTest.php
+++ b/test/DataProvider/InvalidUuidNotNullTest.php
@@ -12,10 +12,8 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUuidNotNull;
 
-class InvalidUuidNotNullTest extends AbstractDataProviderTestCase
+class InvalidUuidNotNullTest extends AbstractNotNullTestCase
 {
-    use NotNull;
-
     protected function className()
     {
         return InvalidUuidNotNull::class;
@@ -30,7 +28,7 @@ class InvalidUuidNotNullTest extends AbstractDataProviderTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::nullOrString($value);
-        Assertion::nullOrUuid($value);
+        Assertion::string($value);
+        Assertion::uuid($value);
     }
 }

--- a/test/DataProvider/InvalidUuidTest.php
+++ b/test/DataProvider/InvalidUuidTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUuid;
 
-class InvalidUuidTest extends AbstractDataProviderTestCase
+class InvalidUuidTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/ScalarTest.php
+++ b/test/DataProvider/ScalarTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\Scalar;
 
-class ScalarTest extends AbstractDataProviderTestCase
+class ScalarTest extends AbstractTestCase
 {
     protected function className()
     {


### PR DESCRIPTION
This PR

* [x] removes imports for the `NotNull` trait where it isn't needed

Follows #64.
