### PR TITLE
Fix: Mark tests as final

### DIFF
--- a/test/DataProvider/BlankStringTest.php
+++ b/test/DataProvider/BlankStringTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\BlankString;
 
-class BlankStringTest extends AbstractTestCase
+final class BlankStringTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/BooleanTest.php
+++ b/test/DataProvider/BooleanTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\Boolean;
 
-class BooleanTest extends AbstractTestCase
+final class BooleanTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/ElementsTest.php
+++ b/test/DataProvider/ElementsTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\Elements;
 
-class ElementsTest extends AbstractTestCase
+final class ElementsTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidBooleanNotNullTest.php
+++ b/test/DataProvider/InvalidBooleanNotNullTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidBooleanNotNull;
 
-class InvalidBooleanNotNullTest extends AbstractNotNullTestCase
+final class InvalidBooleanNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidBooleanTest.php
+++ b/test/DataProvider/InvalidBooleanTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidBoolean;
 
-class InvalidBooleanTest extends AbstractTestCase
+final class InvalidBooleanTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidFloatNotNullTest.php
+++ b/test/DataProvider/InvalidFloatNotNullTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidFloatNotNull;
 
-class InvalidFloatNotNullTest extends AbstractNotNullTestCase
+final class InvalidFloatNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidFloatTest.php
+++ b/test/DataProvider/InvalidFloatTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidFloat;
 
-class InvalidFloatTest extends AbstractTestCase
+final class InvalidFloatTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIntegerNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerNotNullTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidIntegerNotNull;
 
-class InvalidIntegerNotNullTest extends AbstractNotNullTestCase
+final class InvalidIntegerNotNullTest extends AbstractNotNullTestCase
 {
     public function className()
     {

--- a/test/DataProvider/InvalidIntegerTest.php
+++ b/test/DataProvider/InvalidIntegerTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidInteger;
 
-class InvalidIntegerTest extends AbstractTestCase
+final class InvalidIntegerTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIntegerishNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerishNotNullTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIntegerishNotNull;
 
-class InvalidIntegerishNotNullTest extends AbstractNotNullTestCase
+final class InvalidIntegerishNotNullTest extends AbstractNotNullTestCase
 {
     public function className()
     {

--- a/test/DataProvider/InvalidIntegerishTest.php
+++ b/test/DataProvider/InvalidIntegerishTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIntegerish;
 
-class InvalidIntegerishTest extends AbstractTestCase
+final class InvalidIntegerishTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIsoDateNotNullTest.php
+++ b/test/DataProvider/InvalidIsoDateNotNullTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull;
 
-class InvalidIsoDateNotNullTest extends AbstractNotNullTestCase
+final class InvalidIsoDateNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidIsoDateTest.php
+++ b/test/DataProvider/InvalidIsoDateTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidIsoDate;
 
-class InvalidIsoDateTest extends AbstractTestCase
+final class InvalidIsoDateTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidNumericNotNullTest.php
+++ b/test/DataProvider/InvalidNumericNotNullTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidNumericNotNull;
 
-class InvalidNumericNotNullTest extends AbstractNotNullTestCase
+final class InvalidNumericNotNullTest extends AbstractNotNullTestCase
 {
     public function className()
     {

--- a/test/DataProvider/InvalidNumericTest.php
+++ b/test/DataProvider/InvalidNumericTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidNumeric;
 
-class InvalidNumericTest extends AbstractTestCase
+final class InvalidNumericTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidScalarNotNullTest.php
+++ b/test/DataProvider/InvalidScalarNotNullTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidScalarNotNull;
 
-class InvalidScalarNotNullTest extends AbstractNotNullTestCase
+final class InvalidScalarNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidScalarTest.php
+++ b/test/DataProvider/InvalidScalarTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidScalar;
 
-class InvalidScalarTest extends AbstractTestCase
+final class InvalidScalarTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidStringNotNullTest.php
+++ b/test/DataProvider/InvalidStringNotNullTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidStringNotNull;
 
-class InvalidStringNotNullTest extends AbstractNotNullTestCase
+final class InvalidStringNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidStringTest.php
+++ b/test/DataProvider/InvalidStringTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\InvalidString;
 
-class InvalidStringTest extends AbstractTestCase
+final class InvalidStringTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidUrlNotNullTest.php
+++ b/test/DataProvider/InvalidUrlNotNullTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUrlNotNull;
 
-class InvalidUrlNotNullTest extends AbstractNotNullTestCase
+final class InvalidUrlNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUrl;
 
-class InvalidUrlTest extends AbstractTestCase
+final class InvalidUrlTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidUuidNotNullTest.php
+++ b/test/DataProvider/InvalidUuidNotNullTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUuidNotNull;
 
-class InvalidUuidNotNullTest extends AbstractNotNullTestCase
+final class InvalidUuidNotNullTest extends AbstractNotNullTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/InvalidUuidTest.php
+++ b/test/DataProvider/InvalidUuidTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 use Assert\Assertion;
 use Refinery29\Test\Util\DataProvider\InvalidUuid;
 
-class InvalidUuidTest extends AbstractTestCase
+final class InvalidUuidTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProvider/ScalarTest.php
+++ b/test/DataProvider/ScalarTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\DataProvider;
 
 use Refinery29\Test\Util\DataProvider\Scalar;
 
-class ScalarTest extends AbstractTestCase
+final class ScalarTest extends AbstractTestCase
 {
     protected function className()
     {

--- a/test/DataProviderFake.php
+++ b/test/DataProviderFake.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test;
 
 use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 
-class DataProviderFake implements DataProviderInterface
+final class DataProviderFake implements DataProviderInterface
 {
     private $values;
 

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\Test\Util\Test\Faker;
 use Faker\Generator as OriginalGenerator;
 use Refinery29\Test\Util\Faker\Generator;
 
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+final class GeneratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testExtendsBase()
     {

--- a/test/Faker/Provider/ColorTest.php
+++ b/test/Faker/Provider/ColorTest.php
@@ -11,7 +11,7 @@ namespace Refinery29\Test\Util\Test\Faker\Provider;
 
 use Refinery29\Test\Util\Faker\Provider\Color;
 
-class ColorTest extends \PHPUnit_Framework_TestCase
+final class ColorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @link https://github.com/fzaninotto/Faker/blob/v1.5.0/test/Faker/Provider/ColorTest.php#L10-L13

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -13,7 +13,7 @@ use Faker\Generator;
 use Refinery29\Test\Util\Faker\Provider;
 use Refinery29\Test\Util\TestHelper;
 
-class TestHelperTest extends \PHPUnit_Framework_TestCase
+final class TestHelperTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 


### PR DESCRIPTION
This PR

* [x] marks tests as `final`
