### PR TITLE
Fix: Remove Interface from assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ class BazTest extends \PHPUnit_Framework_TestCase
 
 The `TestHelper` also provides an assertion:
 
-* `assertImplementsInterface($interfaceName, $className)`
+* `assertImplements($interfaceName, $className)`
 
 ## Contributing
 

--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -90,7 +90,7 @@ trait TestHelper
      * @param string $interfaceName
      * @param string $className
      */
-    final public function assertImplementsInterface($interfaceName, $className)
+    final public function assertImplements($interfaceName, $className)
     {
         $this->assertTrue(interface_exists($interfaceName), sprintf(
             'Failed to assert that interface "%s" exists',

--- a/test/DataProvider/AbstractTestCase.php
+++ b/test/DataProvider/AbstractTestCase.php
@@ -23,6 +23,6 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 
     final public function testImplementsDataProviderInterface()
     {
-        $this->assertImplementsInterface(DataProviderInterface::class, $this->className());
+        $this->assertImplements(DataProviderInterface::class, $this->className());
     }
 }


### PR DESCRIPTION
This PR

* [x] drops the `Interface` suffix from an assertion

Follows #98.
