### PR TITLE
Fix: Reduce visibility of assertImplements()

### DIFF
--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -108,7 +108,7 @@ trait TestHelper
      * @param string $interfaceName
      * @param string $className
      */
-    final public function assertImplements($interfaceName, $className)
+    final protected function assertImplements($interfaceName, $className)
     {
         $this->assertTrue(interface_exists($interfaceName), sprintf(
             'Failed to assert that interface "%s" exists',

--- a/test/Asset/Foo.php
+++ b/test/Asset/Foo.php
@@ -9,6 +9,9 @@
 
 namespace Refinery29\Test\Util\Test\Asset;
 
-final class Foo
+final class Foo implements \Countable
 {
+    public function count()
+    {
+    }
 }

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -190,6 +190,11 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertFinal(Asset\Foo::class);
     }
 
+    public function testAssertImplements()
+    {
+        $this->assertImplements(\Countable::class, Asset\Foo::class);
+    }
+
     /**
      * @param $generator
      * @param $values


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `assertImplements()` from `public` to `protected`

💁‍♂️ Also adds a missing _explicit_ test!
