### PR TITLE
Fix: Add  missing closing brace

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ final class WebsiteTest extends \PHPUnit_Framework_TestCase
             'http://www.refinery29.uk',
         ]);
     }
-    
+}
 ```
 
 ## Contributing


### PR DESCRIPTION
This PR

* [x] adds a missing closing `}` in an example in `README.md`

Follows #104.
