### PR TITLE
Fix: Use assertion chain in tests

### DIFF
--- a/test/DataProvider/InvalidIntegerishNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerishNotNullTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidIntegerishNotNull;
 
 final class InvalidIntegerishNotNullTest extends AbstractNotNullTestCase
@@ -28,6 +28,6 @@ final class InvalidIntegerishNotNullTest extends AbstractNotNullTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::integerish($value);
+        Assert\that($value)->integerish();
     }
 }

--- a/test/DataProvider/InvalidIntegerishTest.php
+++ b/test/DataProvider/InvalidIntegerishTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidIntegerish;
 
 final class InvalidIntegerishTest extends AbstractTestCase
@@ -28,6 +28,6 @@ final class InvalidIntegerishTest extends AbstractTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::integerish($value);
+        Assert\that($value)->integerish();
     }
 }

--- a/test/DataProvider/InvalidIsoDateNotNullTest.php
+++ b/test/DataProvider/InvalidIsoDateNotNullTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidIsoDateNotNull;
 
 final class InvalidIsoDateNotNullTest extends AbstractNotNullTestCase
@@ -28,7 +28,6 @@ final class InvalidIsoDateNotNullTest extends AbstractNotNullTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::string($value);
-        Assertion::date($value, DATE_ATOM);
+        Assert\that($value)->string()->date(DATE_ATOM);
     }
 }

--- a/test/DataProvider/InvalidIsoDateTest.php
+++ b/test/DataProvider/InvalidIsoDateTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidIsoDate;
 
 final class InvalidIsoDateTest extends AbstractTestCase
@@ -28,7 +28,6 @@ final class InvalidIsoDateTest extends AbstractTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::string($value);
-        Assertion::date($value, DATE_ATOM);
+        Assert\that($value)->string()->date(DATE_ATOM);
     }
 }

--- a/test/DataProvider/InvalidUrlNotNullTest.php
+++ b/test/DataProvider/InvalidUrlNotNullTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidUrlNotNull;
 
 final class InvalidUrlNotNullTest extends AbstractNotNullTestCase
@@ -28,6 +28,6 @@ final class InvalidUrlNotNullTest extends AbstractNotNullTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::url($value);
+        Assert\that($value)->url();
     }
 }

--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidUrl;
 
 final class InvalidUrlTest extends AbstractTestCase
@@ -28,6 +28,6 @@ final class InvalidUrlTest extends AbstractTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::url($value);
+        Assert\that($value)->url();
     }
 }

--- a/test/DataProvider/InvalidUuidNotNullTest.php
+++ b/test/DataProvider/InvalidUuidNotNullTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidUuidNotNull;
 
 final class InvalidUuidNotNullTest extends AbstractNotNullTestCase
@@ -28,7 +28,6 @@ final class InvalidUuidNotNullTest extends AbstractNotNullTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::string($value);
-        Assertion::uuid($value);
+        Assert\that($value)->string()->uuid();
     }
 }

--- a/test/DataProvider/InvalidUuidTest.php
+++ b/test/DataProvider/InvalidUuidTest.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
-use Assert\Assertion;
+use Assert;
 use Refinery29\Test\Util\DataProvider\InvalidUuid;
 
 final class InvalidUuidTest extends AbstractTestCase
@@ -28,7 +28,6 @@ final class InvalidUuidTest extends AbstractTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        Assertion::string($value);
-        Assertion::uuid($value);
+        Assert\that($value)->string()->uuid();
     }
 }


### PR DESCRIPTION
This PR

* [x] uses `Assert\that()` in tests
