### PR TITLE
Fix: Create concrete assets

### DIFF
--- a/test/Asset/ChildClass.php
+++ b/test/Asset/ChildClass.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset;
+
+class ChildClass extends ParentClass
+{
+}

--- a/test/Asset/FinalClass.php
+++ b/test/Asset/FinalClass.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset;
+
+final class FinalClass
+{
+}

--- a/test/Asset/ImplementedInterface.php
+++ b/test/Asset/ImplementedInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset;
+
+interface ImplementedInterface
+{
+}

--- a/test/Asset/ImplementingClass.php
+++ b/test/Asset/ImplementingClass.php
@@ -9,6 +9,6 @@
 
 namespace Refinery29\Test\Util\Test\Asset;
 
-class Bar
+class ImplementingClass implements ImplementedInterface
 {
 }

--- a/test/Asset/NonFinalClass.php
+++ b/test/Asset/NonFinalClass.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset;
+
+class NonFinalClass
+{
+}

--- a/test/Asset/NonImplementingClass.php
+++ b/test/Asset/NonImplementingClass.php
@@ -9,9 +9,6 @@
 
 namespace Refinery29\Test\Util\Test\Asset;
 
-final class Foo extends Bar implements \Countable
+class NonImplementingClass
 {
-    public function count()
-    {
-    }
 }

--- a/test/Asset/ParentClass.php
+++ b/test/Asset/ParentClass.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset;
+
+class ParentClass
+{
+}

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -196,64 +196,64 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
-        $this->assertFinal(\stdClass::class);
+        $this->assertFinal(Asset\NonFinalClass::class);
     }
 
     public function testAssertFinalSucceedsWhenClassIsFinal()
     {
-        $this->assertFinal(Asset\Foo::class);
+        $this->assertFinal(Asset\FinalClass::class);
     }
 
     public function testAssertExtendsFailsWhenParentDoesNotExist()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
-        $this->assertExtends('foobarbaz', \stdClass::class);
+        $this->assertExtends('foobarbaz', Asset\ChildClass::class);
     }
 
     public function testAssertExtendsFailsWhenChildDoesNotExist()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
-        $this->assertExtends(\stdClass::class, 'foobarbaz');
+        $this->assertExtends(Asset\ParentClass::class, 'foobarbaz');
     }
 
     public function testAssertExtendsFailsWhenChildDoesNotExtendParent()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
-        $this->assertExtends(\stdClass::class, Asset\Foo::class);
+        $this->assertExtends(Asset\ChildClass::class, Asset\ParentClass::class);
     }
 
     public function testAssertExtendsSucceedsWhenChildExtendsParent()
     {
-        $this->assertExtends(Asset\Bar::class, Asset\Foo::class);
+        $this->assertExtends(Asset\ParentClass::class, Asset\ChildClass::class);
     }
 
     public function testAssertImplementsFailsWhenInterfaceDoesNotExist()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
-        $this->assertImplements('foobarbaz', \stdClass::class);
+        $this->assertImplements('foobarbaz', Asset\ImplementingClass::class);
     }
 
     public function testAssertImplementsFailsWhenClassDoesNotExist()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
-        $this->assertImplements(\Countable::class, 'foobarbaz');
+        $this->assertImplements(Asset\ImplementedInterface::class, 'foobarbaz');
     }
 
     public function testAssertImplementFailsWhenClassDoesNotImplementInterface()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
-        $this->assertImplements(\Countable::class, \stdClass::class);
+        $this->assertImplements(Asset\ImplementedInterface::class, Asset\NonImplementingClass::class);
     }
 
     public function testAssertImplementSucceedsWhenClassImplementsInterface()
     {
-        $this->assertImplements(\Countable::class, Asset\Foo::class);
+        $this->assertImplements(Asset\ImplementedInterface::class, Asset\ImplementingClass::class);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] creates concrete assets and removes `Foo` and `Bar`

Follows #109.
