### PR TITLE
Fix: Make assertExtends() work with interfaces

### DIFF
--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -105,27 +105,27 @@ trait TestHelper
     }
 
     /**
-     * @param string $parentClassName
-     * @param string $className
+     * @param string $parentName
+     * @param string $childName
      */
-    final protected function assertExtends($parentClassName, $className)
+    final protected function assertExtends($parentName, $childName)
     {
-        $this->assertTrue(class_exists($parentClassName), sprintf(
-            'Failed to assert that class "%s" exists',
-            $parentClassName
+        $this->assertTrue(class_exists($parentName) || interface_exists($parentName), sprintf(
+            'Failed to assert that class or interface "%s" exists',
+            $parentName
         ));
 
-        $this->assertTrue(class_exists($className), sprintf(
-            'Failed to assert that class "%s" exists',
-            $className
+        $this->assertTrue(class_exists($childName) || interface_exists($childName), sprintf(
+            'Failed to assert that class or interface "%s" exists',
+            $childName
         ));
 
-        $reflection = new \ReflectionClass($className);
+        $reflection = new \ReflectionClass($childName);
 
-        $this->assertTrue($reflection->isSubclassOf($parentClassName), sprintf(
+        $this->assertTrue($reflection->isSubclassOf($parentName), sprintf(
             'Failed to assert that "%s" extends "%s"',
-            $className,
-            $parentClassName
+            $childName,
+            $parentName
         ));
     }
 

--- a/test/Asset/ChildInterface.php
+++ b/test/Asset/ChildInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset;
+
+interface ChildInterface extends ParentInterface
+{
+}

--- a/test/Asset/ParentInterface.php
+++ b/test/Asset/ParentInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset;
+
+interface ParentInterface
+{
+}

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -204,30 +204,56 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertFinal(Asset\FinalClass::class);
     }
 
-    public function testAssertExtendsFailsWhenParentDoesNotExist()
+    public function testAssertExtendsFailsWhenParentClassDoesNotExist()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
         $this->assertExtends('foobarbaz', Asset\ChildClass::class);
     }
 
-    public function testAssertExtendsFailsWhenChildDoesNotExist()
+    public function testAssertExtendsFailsWhenParentInterfaceDoesNotExist()
+    {
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+
+        $this->assertExtends('foobarbaz', Asset\ChildInterface::class);
+    }
+
+    public function testAssertExtendsFailsWhenChildClassDoesNotExist()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
         $this->assertExtends(Asset\ParentClass::class, 'foobarbaz');
     }
 
-    public function testAssertExtendsFailsWhenChildDoesNotExtendParent()
+    public function testAssertExtendsFailsWhenChildInterfaceDoesNotExist()
+    {
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+
+        $this->assertExtends(Asset\ParentInterface::class, 'foobarbaz');
+    }
+
+    public function testAssertExtendsFailsWhenChildClassDoesNotExtendParentClass()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
 
         $this->assertExtends(Asset\ChildClass::class, Asset\ParentClass::class);
     }
 
-    public function testAssertExtendsSucceedsWhenChildExtendsParent()
+    public function testAssertExtendsFailsWhenChildInterfaceDoesNotExtendParentInterface()
+    {
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+
+        $this->assertExtends(Asset\ChildInterface::class, Asset\ParentInterface::class);
+    }
+
+    public function testAssertExtendsSucceedsWhenChildClassExtendsParentClass()
     {
         $this->assertExtends(Asset\ParentClass::class, Asset\ChildClass::class);
+    }
+
+    public function testAssertExtendsSucceedsWhenChildInterfaceExtendsParentInterface()
+    {
+        $this->assertExtends(Asset\ParentInterface::class, Asset\ChildInterface::class);
     }
 
     public function testAssertImplementsFailsWhenInterfaceDoesNotExist()


### PR DESCRIPTION
This PR

* [x] asserts that `assertExtends()` works with interfaces
* [x] makes `assertExtends()` work with interfaces

Follows #107.