### PR TITLE
Fix: Make sure we will always round with a precision greater than 0

### DIFF
--- a/src/DataProvider/InvalidBoolean.php
+++ b/src/DataProvider/InvalidBoolean.php
@@ -17,7 +17,7 @@ class InvalidBoolean extends AbstractDataProvider
 
         return [
             'null' => null,
-            'float' => $faker->randomFloat(),
+            'float' => $faker->randomFloat($faker->numberBetween(1)),
             'integer' => $faker->randomNumber(),
             'string' => $faker->word,
             'array' => $faker->words,

--- a/src/DataProvider/InvalidFloat.php
+++ b/src/DataProvider/InvalidFloat.php
@@ -20,7 +20,7 @@ class InvalidFloat extends AbstractDataProvider
             'boolean-true' => true,
             'boolean-false' => false,
             'integer' => $faker->randomNumber(),
-            'float-casted-to-string' => (string) $faker->randomFloat(1),
+            'float-casted-to-string' => (string) $faker->randomFloat($faker->numberBetween(1)),
             'string' => $faker->word,
             'array' => $faker->words,
             'object' => new \stdClass(),

--- a/src/DataProvider/InvalidInteger.php
+++ b/src/DataProvider/InvalidInteger.php
@@ -19,7 +19,7 @@ class InvalidInteger extends AbstractDataProvider
             'null' => null,
             'boolean-true' => true,
             'boolean-false' => false,
-            'float' => $faker->randomFloat(),
+            'float' => $faker->randomFloat($faker->numberBetween(1)),
             'integer-casted-to-string' => (string) $faker->randomNumber(),
             'string' => $faker->word,
             'array' => $faker->words,

--- a/src/DataProvider/InvalidIntegerish.php
+++ b/src/DataProvider/InvalidIntegerish.php
@@ -19,7 +19,7 @@ class InvalidIntegerish extends AbstractDataProvider
             'null' => null,
             'boolean-true' => true,
             'boolean-false' => false,
-            'float' => $faker->randomFloat(),
+            'float' => $faker->randomFloat($faker->numberBetween(1)),
             'string' => $faker->word,
             'array' => $faker->words,
             'object' => new \stdClass(),

--- a/src/DataProvider/InvalidString.php
+++ b/src/DataProvider/InvalidString.php
@@ -19,7 +19,7 @@ class InvalidString extends AbstractDataProvider
             'null' => null,
             'boolean-true' => true,
             'boolean-false' => false,
-            'float' => $faker->randomFloat(),
+            'float' => $faker->randomFloat($faker->numberBetween(1)),
             'integer' => $faker->randomNumber(),
             'array' => $faker->words,
             'object' => new \stdClass(),

--- a/src/DataProvider/Scalar.php
+++ b/src/DataProvider/Scalar.php
@@ -18,7 +18,7 @@ class Scalar extends AbstractDataProvider
         return [
             'boolean-true' => true,
             'boolean-false' => false,
-            'float' => $faker->randomFloat(),
+            'float' => $faker->randomFloat($faker->numberBetween(1)),
             'integer' => $faker->randomNumber(),
             'string' => $faker->word,
         ];


### PR DESCRIPTION
This PR

* [x] fixes an issue where we _may_ randomly provide an `integerish` value when we do not intend to

💁‍♂️ If we don't provide a value for `$nbMaxDecimals`, it will be [randomly created](https://github.com/fzaninotto/Faker/blob/v1.6.0/src/Faker/Provider/Base.php#L107-L109), and may end up being `0`, that is, we'll also end up rounding an actual float with a precision of `0`, and the result will be an integerish number, causing random tests to fail, because an integerish number is provided when we don't expect it to be provided.

For reference, see [`Faker\Provider\Base::randomFloat()`](https://github.com/fzaninotto/Faker/blob/v1.6.0/src/Faker/Provider/Base.php#L105-L122).