### PR TITLE
Fix: Add PHP7.1 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ matrix:
   fast_finish: true
   include:
     - php: 5.6
+    - php: 7.0
       env: WITH_CS=true
-    - php: 7
+    - php: 7.1
       env: WITH_COVERAGE=true
     - php: hhvm
 


### PR DESCRIPTION
This PR

* [x] adds PHP 7.1 to the build matrix
