### PR TITLE
Fix: Do not declare getFaker() as static

### DIFF
--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -18,7 +18,7 @@ trait TestHelper
      *
      * @return Faker\Generator
      */
-    final protected static function getFaker($locale = 'en_US')
+    final protected function getFaker($locale = 'en_US')
     {
         static $fakers = [];
 


### PR DESCRIPTION
This PR

* [x] removes the `static` keyword from `getFaker()`
