### PR TITLE
Fix: Run php-cs-fixer on PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
   fast_finish: true
   include:
     - php: 5.6
-    - php: 7.0
       env: WITH_CS=true
+    - php: 7.0
     - php: 7.1
       env: WITH_COVERAGE=true
 


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` on PHP 5.6

Blocks #123.