### PR TITLE
Enhancement: Implement AbstractTestClassTestCase for asserting test classes are abstract or final

### DIFF
--- a/src/AbstractTestClassTestCase.php
+++ b/src/AbstractTestClassTestCase.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util;
+
+use Assert\Assertion;
+use Symfony\Component\Finder;
+
+/**
+ * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.0.0/tests/ProjectCodeTest.php
+ */
+abstract class AbstractTestClassTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string   $directory
+     * @param string   $psr4Prefix
+     * @param string[] $excludeDirectories
+     *
+     * @throws \InvalidArgumentException
+     */
+    final protected function createTest($directory, $psr4Prefix, array $excludeDirectories = [])
+    {
+        Assertion::directory($directory);
+        Assertion::string($psr4Prefix);
+        Assertion::allDirectory(array_map(function ($excludeDirectory) use ($directory) {
+            return $directory . DIRECTORY_SEPARATOR . $excludeDirectory;
+        }, $excludeDirectories));
+
+        $finder = Finder\Finder::create()
+            ->files()
+            ->name('*.php')
+            ->in($directory)
+            ->exclude($excludeDirectories);
+
+        $exclusion = '';
+        if (count($excludeDirectories)) {
+            $exclusion = sprintf(
+                ' excluding "%s"',
+                implode('", "', $excludeDirectories)
+            );
+        }
+
+        $files = iterator_to_array(
+            $finder,
+            false
+        );
+
+        $this->assertGreaterThan(0, count($files), sprintf(
+            'Could not find any PHP files in directory "%s"%s.',
+            $directory,
+            $exclusion
+        ));
+
+        $psr4Prefix = rtrim($psr4Prefix, '\\');
+
+        array_walk($files, function (Finder\SplFileInfo $file) use ($psr4Prefix) {
+            $className = sprintf(
+                '%s\%s%s%s',
+                $psr4Prefix,
+                strtr($file->getRelativePath(), DIRECTORY_SEPARATOR, '\\'),
+                $file->getRelativePath() ? '\\' : '',
+                $file->getBasename('.' . $file->getExtension())
+            );
+
+            $reflection = new \ReflectionClass($className);
+
+            if ($reflection->isTrait() || $reflection->isInterface()) {
+                return;
+            }
+
+            $this->assertTrue($reflection->isAbstract() || $reflection->isFinal(), sprintf(
+                'Failed to assert that the test class "%s" is abstract or final.',
+                $className
+            ));
+        });
+    }
+}

--- a/test/Asset/HalfEmpty/Bar/Baz.php
+++ b/test/Asset/HalfEmpty/Bar/Baz.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\HalfEmpty\Bar;
+
+class Bar
+{
+}

--- a/test/Asset/HalfEmpty/Foo/Bar.php
+++ b/test/Asset/HalfEmpty/Foo/Bar.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\HalfEmpty\Foo;
+
+class Bar
+{
+}

--- a/test/Asset/NotClasses/Bars.php
+++ b/test/Asset/NotClasses/Bars.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\NotClasses;
+
+trait Bars
+{
+}

--- a/test/Asset/NotClasses/FooInterface.php
+++ b/test/Asset/NotClasses/FooInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\NotClasses;
+
+interface FooInterface
+{
+}

--- a/test/TestClassTest.php
+++ b/test/TestClassTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test;
+
+use Refinery29\Test\Util\AbstractTestClassTestCase;
+
+final class TestClassTest extends AbstractTestClassTestCase
+{
+    public function testCreateTestRejectsNonExistentDirectory()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->createTest(
+            __DIR__ . '/NonExistent',
+            'Refinery29\Test\Util\Test'
+        );
+    }
+
+    /**
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $psr4Prefix
+     */
+    public function testCreateTestRejectsInvalidPsr4Prefix($psr4Prefix)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->createTest(
+            __DIR__,
+            $psr4Prefix
+        );
+    }
+
+    public function testCreateTestRejectsNonExistentExcludedDirectory()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->createTest(
+            __DIR__,
+            'Refinery29\Test\Util\Test',
+            [
+                'NonExistent',
+            ]
+        );
+    }
+
+    public function testCreateTestFailsIfNoPhpFilesHaveBeenFound()
+    {
+        $directory = __DIR__ . '/Asset/Empty';
+
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+        $this->expectExceptionMessage(sprintf(
+            'Could not find any PHP files in directory "%s".',
+            $directory
+        ));
+
+        $this->createTest(
+            $directory,
+            'Refinery29\Test\Util\Test\Asset\Empty'
+        );
+    }
+
+    public function testCreateTestWithExclusionsFailsIfNoPhpFilesHaveBeenFound()
+    {
+        $directory = __DIR__ . '/Asset/HalfEmpty';
+        $exclusions = [
+            'Bar',
+            'Foo',
+        ];
+
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+        $this->expectExceptionMessage(sprintf(
+            'Could not find any PHP files in directory "%s" excluding "%s".',
+            $directory,
+            implode('", "', $exclusions)
+        ));
+
+        $this->createTest(
+            $directory,
+            'Refinery29\Test\Util\Test\Asset\HalfEmpty',
+            $exclusions
+        );
+    }
+
+    public function testCreateTestIgnoresInterfacesAndTraits()
+    {
+        $this->createTest(
+            __DIR__ . '/Asset/NotClasses',
+            'Refinery29\Test\Util\Test\Asset\NotClasses'
+        );
+    }
+
+    public function testTestClassesAreAbstractOrFinal()
+    {
+        $this->createTest(
+            __DIR__,
+            'Refinery29\Test\Util\Test',
+            [
+                'Asset',
+            ]
+        );
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds an `AbstractTestClassTestCase` that allows for asserting that test classes are either `abstract` or `final`

💁‍♂️ Inspired by [`PhpCsFixer\Tests\ProjectCodeTest`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.0.0/tests/ProjectCodeTest.php), written by @keradus.