### PR TITLE
Fix: Remove need to resolve global function in current namespace

### DIFF
--- a/src/AbstractTestClassTestCase.php
+++ b/src/AbstractTestClassTestCase.php
@@ -28,7 +28,7 @@ abstract class AbstractTestClassTestCase extends \PHPUnit_Framework_TestCase
     {
         Assertion::directory($directory);
         Assertion::string($psr4Prefix);
-        Assertion::allDirectory(array_map(function ($excludeDirectory) use ($directory) {
+        Assertion::allDirectory(\array_map(function ($excludeDirectory) use ($directory) {
             return $directory . DIRECTORY_SEPARATOR . $excludeDirectory;
         }, $excludeDirectories));
 
@@ -39,31 +39,31 @@ abstract class AbstractTestClassTestCase extends \PHPUnit_Framework_TestCase
             ->exclude($excludeDirectories);
 
         $exclusion = '';
-        if (count($excludeDirectories)) {
-            $exclusion = sprintf(
+        if (\count($excludeDirectories)) {
+            $exclusion = \sprintf(
                 ' excluding "%s"',
-                implode('", "', $excludeDirectories)
+                \implode('", "', $excludeDirectories)
             );
         }
 
-        $files = iterator_to_array(
+        $files = \iterator_to_array(
             $finder,
             false
         );
 
-        $this->assertGreaterThan(0, count($files), sprintf(
+        $this->assertGreaterThan(0, \count($files), \sprintf(
             'Could not find any PHP files in directory "%s"%s.',
             $directory,
             $exclusion
         ));
 
-        $psr4Prefix = rtrim($psr4Prefix, '\\');
+        $psr4Prefix = \rtrim($psr4Prefix, '\\');
 
-        array_walk($files, function (Finder\SplFileInfo $file) use ($psr4Prefix) {
-            $className = sprintf(
+        \array_walk($files, function (Finder\SplFileInfo $file) use ($psr4Prefix) {
+            $className = \sprintf(
                 '%s\%s%s%s',
                 $psr4Prefix,
-                strtr($file->getRelativePath(), DIRECTORY_SEPARATOR, '\\'),
+                \strtr($file->getRelativePath(), DIRECTORY_SEPARATOR, '\\'),
                 $file->getRelativePath() ? '\\' : '',
                 $file->getBasename('.' . $file->getExtension())
             );
@@ -74,7 +74,7 @@ abstract class AbstractTestClassTestCase extends \PHPUnit_Framework_TestCase
                 return;
             }
 
-            $this->assertTrue($reflection->isAbstract() || $reflection->isFinal(), sprintf(
+            $this->assertTrue($reflection->isAbstract() || $reflection->isFinal(), \sprintf(
                 'Failed to assert that the test class "%s" is abstract or final.',
                 $className
             ));

--- a/src/DataProvider/InvalidIsoDate.php
+++ b/src/DataProvider/InvalidIsoDate.php
@@ -17,7 +17,7 @@ class InvalidIsoDate extends InvalidString
 
         $date = $faker->dateTime;
 
-        return array_merge(parent::values(), [
+        return \array_merge(parent::values(), [
             'string' => $faker->word,
             DATE_ISO8601 => $date->format(DATE_ISO8601),
             DATE_COOKIE => $date->format(DATE_COOKIE),

--- a/src/DataProvider/InvalidUrl.php
+++ b/src/DataProvider/InvalidUrl.php
@@ -15,9 +15,9 @@ class InvalidUrl extends InvalidString
     {
         $faker = $this->getFaker();
 
-        return array_merge(parent::values(), [
+        return \array_merge(parent::values(), [
             'string-word-only' => $faker->word,
-            'string-path-only' => implode('/', $faker->words),
+            'string-path-only' => \implode('/', $faker->words),
         ]);
     }
 }

--- a/src/DataProvider/InvalidUuid.php
+++ b/src/DataProvider/InvalidUuid.php
@@ -15,7 +15,7 @@ class InvalidUuid extends InvalidString
     {
         $faker = $this->getFaker();
 
-        return array_merge(parent::values(), [
+        return \array_merge(parent::values(), [
             'string' => $faker->word,
             'md5' => $faker->md5,
             'sha1' => $faker->sha1,

--- a/src/DataProvider/NotNull.php
+++ b/src/DataProvider/NotNull.php
@@ -21,7 +21,7 @@ trait NotNull
      */
     public function notNull(array $values)
     {
-        return array_filter($values, function ($value) {
+        return \array_filter($values, function ($value) {
             return $value !== null;
         });
     }

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -18,7 +18,7 @@ class Color
      */
     public static function hexColorWithAlpha()
     {
-        return '#' . str_pad(dechex(mt_rand(1, 4294967295)), 8, '0', STR_PAD_LEFT);
+        return '#' . str_pad(\dechex(\mt_rand(1, 4294967295)), 8, '0', STR_PAD_LEFT);
     }
 
     /**
@@ -26,6 +26,6 @@ class Color
      */
     public static function hexColorShort()
     {
-        return '#' . str_pad(dechex(mt_rand(1, 4095)), 3, '0', STR_PAD_LEFT);
+        return '#' . str_pad(\dechex(\mt_rand(1, 4095)), 3, '0', STR_PAD_LEFT);
     }
 }

--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -22,11 +22,11 @@ trait TestHelper
     {
         static $fakers = [];
 
-        if (!is_string($locale)) {
+        if (!\is_string($locale)) {
             throw new \InvalidArgumentException('Locale should be a string');
         }
 
-        if (!array_key_exists($locale, $fakers)) {
+        if (!\array_key_exists($locale, $fakers)) {
             $faker = Factory::create($locale);
             $faker->addProvider(new Faker\Provider\Color());
             $faker->seed(9000);
@@ -62,20 +62,20 @@ trait TestHelper
          * This works around @link https://github.com/facebook/hhvm/issues/6954, otherwise we would just type-hint in
          * the method signature above.
          */
-        $dataProviders = array_map(function (DataProvider\DataProviderInterface $dataProvider) {
+        $dataProviders = \array_map(function (DataProvider\DataProviderInterface $dataProvider) {
             return $dataProvider;
         }, $dataProviders);
 
-        $values = array_reduce(
+        $values = \array_reduce(
             $dataProviders,
             function (array $carry, DataProvider\DataProviderInterface $dataProvider) {
                 $values = $dataProvider->values();
 
                 if ($values instanceof \Traversable) {
-                    $values = iterator_to_array($values);
+                    $values = \iterator_to_array($values);
                 }
 
-                return array_merge(
+                return \array_merge(
                     $carry,
                     $values
                 );
@@ -91,14 +91,14 @@ trait TestHelper
      */
     final protected function assertFinal($className)
     {
-        $this->assertTrue(class_exists($className), sprintf(
+        $this->assertTrue(\class_exists($className), \sprintf(
             'Failed to assert that class "%s" exists',
             $className
         ));
 
         $reflection = new \ReflectionClass($className);
 
-        $this->assertTrue($reflection->isFinal(), sprintf(
+        $this->assertTrue($reflection->isFinal(), \sprintf(
             'Failed to assert that "%s" is final',
             $className
         ));
@@ -110,19 +110,19 @@ trait TestHelper
      */
     final protected function assertExtends($parentName, $childName)
     {
-        $this->assertTrue(class_exists($parentName) || interface_exists($parentName), sprintf(
+        $this->assertTrue(\class_exists($parentName) || interface_exists($parentName), \sprintf(
             'Failed to assert that class or interface "%s" exists',
             $parentName
         ));
 
-        $this->assertTrue(class_exists($childName) || interface_exists($childName), sprintf(
+        $this->assertTrue(\class_exists($childName) || interface_exists($childName), \sprintf(
             'Failed to assert that class or interface "%s" exists',
             $childName
         ));
 
         $reflection = new \ReflectionClass($childName);
 
-        $this->assertTrue($reflection->isSubclassOf($parentName), sprintf(
+        $this->assertTrue($reflection->isSubclassOf($parentName), \sprintf(
             'Failed to assert that "%s" extends "%s"',
             $childName,
             $parentName
@@ -135,19 +135,19 @@ trait TestHelper
      */
     final protected function assertImplements($interfaceName, $className)
     {
-        $this->assertTrue(interface_exists($interfaceName), sprintf(
+        $this->assertTrue(\interface_exists($interfaceName), \sprintf(
             'Failed to assert that interface "%s" exists',
             $interfaceName
         ));
 
-        $this->assertTrue(class_exists($className), sprintf(
+        $this->assertTrue(\class_exists($className), \sprintf(
             'Failed to assert that class "%s" exists',
             $className
         ));
 
         $reflection = new \ReflectionClass($className);
 
-        $this->assertTrue($reflection->implementsInterface($interfaceName), sprintf(
+        $this->assertTrue($reflection->implementsInterface($interfaceName), \sprintf(
             'Failed to assert that "%s" implements "%s"',
             $className,
             $interfaceName

--- a/test/DataProvider/BlankStringTest.php
+++ b/test/DataProvider/BlankStringTest.php
@@ -26,6 +26,6 @@ final class BlankStringTest extends AbstractTestCase
     public function testIsBlankString($value)
     {
         $this->assertInternalType('string', $value);
-        $this->assertSame('', trim($value));
+        $this->assertSame('', \trim($value));
     }
 }

--- a/test/DataProvider/BooleanTest.php
+++ b/test/DataProvider/BooleanTest.php
@@ -25,6 +25,6 @@ final class BooleanTest extends AbstractTestCase
      */
     public function testIsABoolean($value)
     {
-        $this->assertTrue(is_bool($value));
+        $this->assertTrue(\is_bool($value));
     }
 }

--- a/test/DataProvider/InvalidBooleanNotNullTest.php
+++ b/test/DataProvider/InvalidBooleanNotNullTest.php
@@ -25,6 +25,6 @@ final class InvalidBooleanNotNullTest extends AbstractNotNullTestCase
      */
     public function testIsNotABoolean($value)
     {
-        $this->assertFalse(is_bool($value));
+        $this->assertFalse(\is_bool($value));
     }
 }

--- a/test/DataProvider/InvalidBooleanTest.php
+++ b/test/DataProvider/InvalidBooleanTest.php
@@ -25,6 +25,6 @@ final class InvalidBooleanTest extends AbstractTestCase
      */
     public function testIsNotABoolean($value)
     {
-        $this->assertFalse(is_bool($value));
+        $this->assertFalse(\is_bool($value));
     }
 }

--- a/test/DataProvider/InvalidFloatNotNullTest.php
+++ b/test/DataProvider/InvalidFloatNotNullTest.php
@@ -25,6 +25,6 @@ final class InvalidFloatNotNullTest extends AbstractNotNullTestCase
      */
     public function testIsNotAFloat($value)
     {
-        $this->assertFalse(is_float($value));
+        $this->assertFalse(\is_float($value));
     }
 }

--- a/test/DataProvider/InvalidFloatTest.php
+++ b/test/DataProvider/InvalidFloatTest.php
@@ -25,6 +25,6 @@ final class InvalidFloatTest extends AbstractTestCase
      */
     public function testIsNotAFloat($value)
     {
-        $this->assertFalse(is_float($value));
+        $this->assertFalse(\is_float($value));
     }
 }

--- a/test/DataProvider/InvalidIntegerNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerNotNullTest.php
@@ -25,6 +25,6 @@ final class InvalidIntegerNotNullTest extends AbstractNotNullTestCase
      */
     public function testIsNotAnInteger($value)
     {
-        $this->assertFalse(is_int($value));
+        $this->assertFalse(\is_int($value));
     }
 }

--- a/test/DataProvider/InvalidIntegerTest.php
+++ b/test/DataProvider/InvalidIntegerTest.php
@@ -25,6 +25,6 @@ final class InvalidIntegerTest extends AbstractTestCase
      */
     public function testIsNotAnInteger($value)
     {
-        $this->assertFalse(is_int($value));
+        $this->assertFalse(\is_int($value));
     }
 }

--- a/test/DataProvider/InvalidNumericNotNullTest.php
+++ b/test/DataProvider/InvalidNumericNotNullTest.php
@@ -25,6 +25,6 @@ final class InvalidNumericNotNullTest extends AbstractNotNullTestCase
      */
     public function testIsNotNumeric($value)
     {
-        $this->assertFalse(is_numeric($value));
+        $this->assertFalse(\is_numeric($value));
     }
 }

--- a/test/DataProvider/InvalidNumericTest.php
+++ b/test/DataProvider/InvalidNumericTest.php
@@ -25,6 +25,6 @@ final class InvalidNumericTest extends AbstractTestCase
      */
     public function testIsNotNumeric($value)
     {
-        $this->assertFalse(is_numeric($value));
+        $this->assertFalse(\is_numeric($value));
     }
 }

--- a/test/DataProvider/InvalidScalarNotNullTest.php
+++ b/test/DataProvider/InvalidScalarNotNullTest.php
@@ -25,6 +25,6 @@ final class InvalidScalarNotNullTest extends AbstractNotNullTestCase
      */
     public function testIsNotAScalar($value)
     {
-        $this->assertFalse(is_scalar($value));
+        $this->assertFalse(\is_scalar($value));
     }
 }

--- a/test/DataProvider/InvalidScalarTest.php
+++ b/test/DataProvider/InvalidScalarTest.php
@@ -25,6 +25,6 @@ final class InvalidScalarTest extends AbstractTestCase
      */
     public function testIsNotAScalar($value)
     {
-        $this->assertFalse(is_scalar($value));
+        $this->assertFalse(\is_scalar($value));
     }
 }

--- a/test/DataProvider/InvalidStringNotNullTest.php
+++ b/test/DataProvider/InvalidStringNotNullTest.php
@@ -25,6 +25,6 @@ final class InvalidStringNotNullTest extends AbstractNotNullTestCase
      */
     public function testIsNotAString($value)
     {
-        $this->assertFalse(is_string($value));
+        $this->assertFalse(\is_string($value));
     }
 }

--- a/test/DataProvider/InvalidStringTest.php
+++ b/test/DataProvider/InvalidStringTest.php
@@ -25,6 +25,6 @@ final class InvalidStringTest extends AbstractTestCase
      */
     public function testIsNotAString($value)
     {
-        $this->assertFalse(is_string($value));
+        $this->assertFalse(\is_string($value));
     }
 }

--- a/test/DataProvider/ScalarTest.php
+++ b/test/DataProvider/ScalarTest.php
@@ -25,6 +25,6 @@ final class ScalarTest extends AbstractTestCase
      */
     public function testIsAScalar($value)
     {
-        $this->assertTrue(is_scalar($value));
+        $this->assertTrue(\is_scalar($value));
     }
 }

--- a/test/TestClassTest.php
+++ b/test/TestClassTest.php
@@ -56,7 +56,7 @@ final class TestClassTest extends AbstractTestClassTestCase
         $directory = __DIR__ . '/Asset/Empty';
 
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectExceptionMessage(\sprintf(
             'Could not find any PHP files in directory "%s".',
             $directory
         ));
@@ -76,10 +76,10 @@ final class TestClassTest extends AbstractTestClassTestCase
         ];
 
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
-        $this->expectExceptionMessage(sprintf(
+        $this->expectExceptionMessage(\sprintf(
             'Could not find any PHP files in directory "%s" excluding "%s".',
             $directory,
-            implode('", "', $exclusions)
+            \implode('", "', $exclusions)
         ));
 
         $this->createTest(

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -107,7 +107,7 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     {
         $reflection = new \ReflectionClass(Provider\Color::class);
 
-        return $this->provideData(array_map(function (\ReflectionMethod $method) {
+        return $this->provideData(\array_map(function (\ReflectionMethod $method) {
             return $method->getName();
         }, $reflection->getMethods()));
     }
@@ -116,7 +116,7 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $values = array_combine(
+        $values = \array_combine(
             $faker->unique()->words(5),
             $faker->unique()->words(5)
         );
@@ -130,7 +130,7 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $values = array_combine(
+        $values = \array_combine(
             $faker->unique()->words(5),
             $faker->unique()->words(5)
         );
@@ -146,7 +146,7 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $values = array_combine(
+        $values = \array_combine(
             $faker->unique()->words(5),
             $faker->unique()->words(5)
         );
@@ -162,12 +162,12 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $valuesOne = array_combine(
+        $valuesOne = \array_combine(
             $faker->unique()->words(5),
             $faker->unique()->words(5)
         );
 
-        $valuesTwo = array_combine(
+        $valuesTwo = \array_combine(
             $faker->unique()->words(5),
             $faker->unique()->words(5)
         );
@@ -177,7 +177,7 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
             new DataProviderFake($this->traversableFrom($valuesTwo))
         );
 
-        $values = array_merge(
+        $values = \array_merge(
             $valuesOne,
             $valuesTwo
         );
@@ -290,13 +290,13 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(\Traversable::class, $generator);
 
-        $expected = array_map(function ($value, $key) {
+        $expected = \array_map(function ($value, $key) {
             return [
                 $key => $value,
             ];
-        }, array_values($values), array_keys($values));
+        }, \array_values($values), \array_keys($values));
 
-        $this->assertSame($expected, iterator_to_array($generator));
+        $this->assertSame($expected, \iterator_to_array($generator));
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes the need to look up global functions in current namespace

💁‍♂️ For reference, see 

* https://twitter.com/Ocramius/status/811504929357660160
* http://php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.shortname2
* http://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/

>Function or constant names that do not contain a backslash like name can be resolved in 2 different ways.
>
>First, the current namespace name is prepended to _name_.
>
>Finally, if the constant or function _name_ does not exist in the current namespace, a global constant or function _name_ is used if it exists.