### PR TITLE
Fix: Specify phony targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: composer coverage cs it test
+
 it: cs test
 
 composer:


### PR DESCRIPTION
This PR

* [x] specifies phony targets in `Makefile`