### PR TITLE
Fix: Require phpunit/phpunit as actual dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "fzaninotto/faker": "^1.5.1"
+        "fzaninotto/faker": "^1.5.1",
+        "phpunit/phpunit": "^5.2.0"
     },
     "require-dev": {
         "beberlei/assert": "^2.6.5",
         "codeclimate/php-test-reporter": "0.3.2",
-        "phpunit/phpunit": "^5.2.0",
         "refinery29/php-cs-fixer-config": "0.6.7"
     },
     "autoload": {


### PR DESCRIPTION
This PR

* [x] requires `phpunit/phpunit` as actual dependency