### PR TITLE
Fix: Make dependency on symfony/finder explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "fzaninotto/faker": "^1.5.1",
-        "phpunit/phpunit": "^5.2.0"
+        "phpunit/phpunit": "^5.2.0",
+        "symfony/finder": "^2.0.0 || ^3.0.0"
     },
     "require-dev": {
         "beberlei/assert": "^2.6.5",


### PR DESCRIPTION
This PR

* [x] makes the dependency on `symfony/finder` explicit

Follows #125.