### PR TITLE
Enhancement: Do not require to specify PSR-4 prefix for asserting classes are abstract or final

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "php": "^5.6 || ^7.0",
         "fzaninotto/faker": "^1.5.1",
         "phpunit/phpunit": "^5.2.0",
-        "symfony/finder": "^2.0.0 || ^3.0.0"
+        "symfony/finder": "^2.0.0 || ^3.0.0",
+        "zendframework/zend-file": "^2.3.4"
     },
     "require-dev": {
         "beberlei/assert": "^2.7.1",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "php": "^5.6 || ^7.0",
         "fzaninotto/faker": "^1.5.1",
         "phpunit/phpunit": "^5.2.0",
-        "symfony/finder": "^2.0.0 || ^3.0.0",
         "zendframework/zend-file": "^2.3.4"
     },
     "require-dev": {

--- a/test/Asset/NotClasses/BarTrait.php
+++ b/test/Asset/NotClasses/BarTrait.php
@@ -9,6 +9,6 @@
 
 namespace Refinery29\Test\Util\Test\Asset\NotClasses;
 
-trait Bars
+trait BarTrait
 {
 }

--- a/test/Asset/NotEmpty/Bar/Baz.php
+++ b/test/Asset/NotEmpty/Bar/Baz.php
@@ -7,8 +7,8 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Refinery29\Test\Util\Test\Asset\HalfEmpty\Foo;
+namespace Refinery29\Test\Util\Test\Asset\NotEmpty\Bar;
 
-class Bar
+class Baz
 {
 }

--- a/test/Asset/NotEmpty/Foo/Bar.php
+++ b/test/Asset/NotEmpty/Foo/Bar.php
@@ -7,7 +7,7 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Refinery29\Test\Util\Test\Asset\HalfEmpty\Bar;
+namespace Refinery29\Test\Util\Test\Asset\NotEmpty\Foo;
 
 class Bar
 {

--- a/test/TestClassTest.php
+++ b/test/TestClassTest.php
@@ -13,98 +13,114 @@ use Refinery29\Test\Util\AbstractTestClassTestCase;
 
 final class TestClassTest extends AbstractTestClassTestCase
 {
-    public function testCreateTestRejectsNonExistentDirectory()
+    /**
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $path
+     */
+    public function testCreateTestRejectsInvalidPath($path)
     {
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Path needs to be specified as a string, got "%s".',
+            \is_object($path) ? \get_class($path) : \gettype($path)
+        ));
 
-        $this->createTest(
-            __DIR__ . '/NonExistent',
-            'Refinery29\Test\Util\Test'
-        );
+        $this->createTest($path);
+    }
+
+    public function testCreateTestRejectsNonExistentPath()
+    {
+        $path = __DIR__ . '/NonExistent';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Path needs to be specified as an existing directory, got "%s".',
+            $path
+        ));
+
+        $this->createTest($path);
     }
 
     /**
      * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
      *
-     * @param mixed $psr4Prefix
+     * @param mixed $excludeDirectory
      */
-    public function testCreateTestRejectsInvalidPsr4Prefix($psr4Prefix)
+    public function testCreateTestRejectsInvalidExcludeDirectory($excludeDirectory)
     {
         $this->expectException(\InvalidArgumentException::class);
-
-        $this->createTest(
-            __DIR__,
-            $psr4Prefix
-        );
-    }
-
-    public function testCreateTestRejectsNonExistentExcludedDirectory()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $this->createTest(
-            __DIR__,
-            'Refinery29\Test\Util\Test',
-            [
-                'NonExistent',
-            ]
-        );
-    }
-
-    public function testCreateTestFailsIfNoPhpFilesHaveBeenFound()
-    {
-        $directory = __DIR__ . '/Asset/Empty';
-
-        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Could not find any PHP files in directory "%s".',
-            $directory
+            'Exclude directory needs to be specified as a string, got "%s".',
+            \is_object($excludeDirectory) ? \get_class($excludeDirectory) : \gettype($excludeDirectory)
+        ));
+
+        $this->createTest(__DIR__, [
+            $excludeDirectory,
+        ]);
+    }
+
+    public function testCreateTestRejectsNonExistentExcludeDirectory()
+    {
+        $path = __DIR__;
+        $excludeDirectory = 'NonExistent';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Exclude directory needs to point to an existing directory within "%s", got "%s".',
+            $path,
+            $excludeDirectory
         ));
 
         $this->createTest(
-            $directory,
-            'Refinery29\Test\Util\Test\Asset\Empty'
-        );
+            $path, [
+            $excludeDirectory,
+        ]);
     }
 
-    public function testCreateTestWithExclusionsFailsIfNoPhpFilesHaveBeenFound()
+    public function testCreateTestFailsIfNoRelevantPhpFilesHaveBeenFound()
     {
-        $directory = __DIR__ . '/Asset/HalfEmpty';
-        $exclusions = [
+        $path = __DIR__ . '/Asset/Empty';
+
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Could not find any relevant PHP files in path "%s".',
+            $path
+        ));
+
+        $this->createTest($path);
+    }
+
+    public function testCreateTestWithExclusionsFailsIfNoRelevantPhpFilesHaveBeenFound()
+    {
+        $path = __DIR__ . '/Asset/NotEmpty';
+        $excludeDirectories = [
             'Bar',
             'Foo',
         ];
 
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Could not find any PHP files in directory "%s" excluding "%s".',
-            $directory,
-            \implode('", "', $exclusions)
+            'Could not find any relevant PHP files in path "%s" excluding "%s".',
+            $path,
+            \implode('", "', $excludeDirectories)
         ));
 
         $this->createTest(
-            $directory,
-            'Refinery29\Test\Util\Test\Asset\HalfEmpty',
-            $exclusions
+            $path,
+            $excludeDirectories
         );
     }
 
     public function testCreateTestIgnoresInterfacesAndTraits()
     {
-        $this->createTest(
-            __DIR__ . '/Asset/NotClasses',
-            'Refinery29\Test\Util\Test\Asset\NotClasses'
-        );
+        $this->createTest(__DIR__ . '/Asset/NotClasses');
     }
 
     public function testTestClassesAreAbstractOrFinal()
     {
-        $this->createTest(
-            __DIR__,
-            'Refinery29\Test\Util\Test',
-            [
-                'Asset',
-            ]
-        );
+        $this->createTest(__DIR__, [
+            'Asset',
+        ]);
     }
 }


### PR DESCRIPTION
This PR

* [x] requires `zendframework/zend-file`
* [x] allows to assert that classes are `final` or `abstract` without needing to specify a PSR-4 prefix
* [x] removes `symfony/finder`