### PR TITLE
Fix: Exclude directories only, not files containing exclude directory in name

### DIFF
--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -202,7 +202,7 @@ trait TestHelper
         );
 
         $excludePaths = \array_map(function ($excludeDirectory) use ($path) {
-            return \realpath($path . DIRECTORY_SEPARATOR . $excludeDirectory);
+            return \realpath($path . DIRECTORY_SEPARATOR . $excludeDirectory) . DIRECTORY_SEPARATOR;
         }, $excludeDirectories);
 
         $classNames = \array_reduce(

--- a/test/Asset/WithExclude/Exclude.php
+++ b/test/Asset/WithExclude/Exclude.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\WithExclude;
+
+class Exclude
+{
+}

--- a/test/Asset/WithExclude/Exclude/Foo.php
+++ b/test/Asset/WithExclude/Exclude/Foo.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\WithExclude\Exclude;
+
+class Foo
+{
+}

--- a/test/Asset/WithExclude/ExcludeNot/Bar.php
+++ b/test/Asset/WithExclude/ExcludeNot/Bar.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\WithExclude\ExcludeNot;
+
+class Bar
+{
+}

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -381,6 +381,30 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAssertClassesAreAbstractOrFinalWithExclusionsHonorsDirectoriesOnly()
+    {
+        $path = __DIR__ . '/Asset/WithExclude';
+        $excludeDirectories = [
+            'Exclude',
+        ];
+
+        $classNamesNeitherAbstractNorFinal = [
+            Asset\WithExclude\Exclude::class,
+            Asset\WithExclude\ExcludeNot\Bar::class,
+        ];
+
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Failed to assert that the following classes are abstract or final: %s',
+            PHP_EOL . ' - ' . \implode(PHP_EOL . ' - ', $classNamesNeitherAbstractNorFinal)
+        ));
+
+        $this->assertClassesAreAbstractOrFinal(
+            $path,
+            $excludeDirectories
+        );
+    }
+
     public function testAssertClassesAreAbstractOrFinalIgnoresInterfacesAndTraits()
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/Asset/NotClasses');


### PR DESCRIPTION
This PR

* [x] asserts that `assertClassesAreAbstractOrfinal()` honors directories only, not files or directories starting with an exclude directory
* [x] honors directories only, not files or directories starting with an exclude directory 

Follows #135.