### PR TITLE
Fix: Do not require, but suggest phpunit/phpunit as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,16 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "fzaninotto/faker": "^1.5.1",
-        "phpunit/phpunit": "^5.2.0",
         "zendframework/zend-file": "^2.7.1"
     },
     "require-dev": {
         "beberlei/assert": "^2.7.1",
         "codeclimate/php-test-reporter": "0.4.0",
+        "phpunit/phpunit": "^5.2.0",
         "refinery29/php-cs-fixer-config": "0.6.7"
+    },
+    "suggest": {
+        "phpunit/phpunit": "If you want to make use of the assertions provided with the TestHelper"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR

* [x] requires `phpunit/phpunit` as a development dependency

💁‍♂️ It's not actually a dependency, but it makes sense to use it with `phpunit/phpunit`.