### PR TITLE
Fix: Allow to pass in plain exception message (without %s)

### DIFF
--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -173,7 +173,7 @@ trait TestHelper
             },
             $path,
             $excludeDirectories,
-            'Failed to assert that the following classes are abstract or final: %s'
+            'Failed to assert that classes are abstract or final.'
         );
     }
 
@@ -265,11 +265,11 @@ trait TestHelper
             return false === $isSatisfied;
         });
 
-        $message = $message ?: 'Failed to assert that the following classes satisfy the specification: %s';
+        $message = $message ?: 'Failed to assert that classes satisfy the specification.';
 
-        $this->assertEmpty($classNamesNotSatisfyingSpecification, \sprintf(
-            $message,
-            PHP_EOL . ' - ' . \implode(PHP_EOL . ' - ', $classNamesNotSatisfyingSpecification)
+        $this->assertEmpty(
+            $classNamesNotSatisfyingSpecification,
+            $message . PHP_EOL . ' - ' . \implode(PHP_EOL . ' - ', $classNamesNotSatisfyingSpecification
         ));
     }
 }

--- a/test/Asset/Message/Foo.php
+++ b/test/Asset/Message/Foo.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\Test\Util\Test\Asset\Message;
+
+final class Foo
+{
+}

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -408,7 +408,7 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
         $this->expectExceptionMessage(\sprintf(
-            'Failed to assert that the following classes are abstract or final: %s',
+            'Failed to assert that classes are abstract or final.%s',
             PHP_EOL . ' - ' . \implode(PHP_EOL . ' - ', $classNamesNeitherAbstractNorFinal)
         ));
 
@@ -628,6 +628,27 @@ final class TestHelperTest extends \PHPUnit_Framework_TestCase
     public static function satisfy(\ReflectionClass $reflection)
     {
         return satisfy($reflection);
+    }
+
+    public function testAssertClassesSatisfyAcceptsMessage()
+    {
+        $message = 'We do not like these classes.';
+
+        $classNames = [
+            Asset\Message\Foo::class,
+        ];
+
+        $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);
+        $this->expectExceptionMessage($message . PHP_EOL . ' - ' . \implode(PHP_EOL . ' - ', $classNames));
+
+        $this->assertClassesSatisfy(
+            function () {
+                return false;
+            },
+            __DIR__ . '/Asset/Message',
+            [],
+            $message
+        );
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] adjusts `assertClassesSatisfy()` that one can pass in a plain exception message (without %s)

Follows #140.