### PR TITLE
Fix: Ensure that integers are never 0

### DIFF
--- a/src/DataProvider/InvalidBoolean.php
+++ b/src/DataProvider/InvalidBoolean.php
@@ -18,7 +18,7 @@ class InvalidBoolean extends AbstractDataProvider
         return [
             'null' => null,
             'float' => $faker->randomFloat(3, 0.001),
-            'integer' => $faker->randomNumber(),
+            'integer' => $faker->numberBetween(1),
             'string' => $faker->word,
             'array' => $faker->words,
             'object' => new \stdClass(),

--- a/src/DataProvider/InvalidFloat.php
+++ b/src/DataProvider/InvalidFloat.php
@@ -19,7 +19,7 @@ class InvalidFloat extends AbstractDataProvider
             'null' => null,
             'boolean-true' => true,
             'boolean-false' => false,
-            'integer' => $faker->randomNumber(),
+            'integer' => $faker->numberBetween(1),
             'float-casted-to-string' => (string) $faker->randomFloat(3, 0.001),
             'string' => $faker->word,
             'array' => $faker->words,

--- a/src/DataProvider/InvalidInteger.php
+++ b/src/DataProvider/InvalidInteger.php
@@ -20,7 +20,7 @@ class InvalidInteger extends AbstractDataProvider
             'boolean-true' => true,
             'boolean-false' => false,
             'float' => $faker->randomFloat(3, 0.001),
-            'integer-casted-to-string' => (string) $faker->randomNumber(),
+            'integer-casted-to-string' => (string) $faker->numberBetween(1),
             'string' => $faker->word,
             'array' => $faker->words,
             'object' => new \stdClass(),

--- a/src/DataProvider/InvalidString.php
+++ b/src/DataProvider/InvalidString.php
@@ -20,7 +20,7 @@ class InvalidString extends AbstractDataProvider
             'boolean-true' => true,
             'boolean-false' => false,
             'float' => $faker->randomFloat(3, 0.001),
-            'integer' => $faker->randomNumber(),
+            'integer' => $faker->numberBetween(1),
             'array' => $faker->words,
             'object' => new \stdClass(),
         ];

--- a/src/DataProvider/Scalar.php
+++ b/src/DataProvider/Scalar.php
@@ -19,7 +19,7 @@ class Scalar extends AbstractDataProvider
             'boolean-true' => true,
             'boolean-false' => false,
             'float' => $faker->randomFloat(3, 0.001),
-            'integer' => $faker->randomNumber(),
+            'integer' => $faker->numberBetween(1),
             'string' => $faker->word,
         ];
     }


### PR DESCRIPTION
This PR

* [x] ensures that integers are never `0`

Follows #149.