### PR TITLE
Fix: Use namespaced PHPUnit test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ If you want to make use of the test helper, import the `Refinery29\Test\Util\Tes
 ```php
 namespace Acme\Test;
 
+use PHPUnit\Framework;
 use Refinery29\Test\Util\TestHelper;
 
-final class WebsiteTest extends \PHPUnit_Framework_TestCase
+
+final class WebsiteTest extends Framework\TestCase
 {
     use TestHelper;
 }
@@ -125,10 +127,11 @@ Putting it all together, here's an example of a test making use of the test help
 namespace Acme\Test;
 
 use Acme\Website;
+use PHPUnit\Framework;
 use Refinery29\Test\Util\DataProvider;
 use Refinery29\Test\Util\TestHelper;
 
-final class WebsiteTest extends \PHPUnit_Framework_TestCase
+final class WebsiteTest extends Framework\TestCase
 {
     use TestHelper;
 

--- a/test/DataProvider/AbstractTestCase.php
+++ b/test/DataProvider/AbstractTestCase.php
@@ -9,10 +9,11 @@
 
 namespace Refinery29\Test\Util\Test\DataProvider;
 
+use PHPUnit\Framework;
 use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 use Refinery29\Test\Util\TestHelper;
 
-abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractTestCase extends Framework\TestCase
 {
     use TestHelper;
 

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -10,9 +10,10 @@
 namespace Refinery29\Test\Util\Test\Faker;
 
 use Faker\Generator as OriginalGenerator;
+use PHPUnit\Framework;
 use Refinery29\Test\Util\Faker\Generator;
 
-final class GeneratorTest extends \PHPUnit_Framework_TestCase
+final class GeneratorTest extends Framework\TestCase
 {
     public function testExtendsBase()
     {

--- a/test/Faker/Provider/ColorTest.php
+++ b/test/Faker/Provider/ColorTest.php
@@ -9,9 +9,10 @@
 
 namespace Refinery29\Test\Util\Test\Faker\Provider;
 
+use PHPUnit\Framework;
 use Refinery29\Test\Util\Faker\Provider\Color;
 
-final class ColorTest extends \PHPUnit_Framework_TestCase
+final class ColorTest extends Framework\TestCase
 {
     /**
      * @link https://github.com/fzaninotto/Faker/blob/v1.5.0/test/Faker/Provider/ColorTest.php#L10-L13

--- a/test/TestClassTest.php
+++ b/test/TestClassTest.php
@@ -9,9 +9,10 @@
 
 namespace Refinery29\Test\Util\Test;
 
+use PHPUnit\Framework;
 use Refinery29\Test\Util\TestHelper;
 
-final class TestClassTest extends \PHPUnit_Framework_TestCase
+final class TestClassTest extends Framework\TestCase
 {
     use TestHelper;
 

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -10,6 +10,7 @@
 namespace Refinery29\Test\Util\Test;
 
 use Faker\Generator;
+use PHPUnit\Framework;
 use Refinery29\Test\Util\Faker\Provider;
 use Refinery29\Test\Util\Test\Asset\WithExclude\ExcludeNot\Bar;
 use Refinery29\Test\Util\TestHelper;
@@ -26,7 +27,7 @@ function satisfy(\ReflectionClass $reflection)
     return $name === Asset\Satisfy\Foo::class;
 }
 
-final class TestHelperTest extends \PHPUnit_Framework_TestCase
+final class TestHelperTest extends Framework\TestCase
 {
     use TestHelper;
 


### PR DESCRIPTION
This PR

* [x] makes use of the namespaced PHPUnit test case