### PR TITLE
Fix: Streamline test method names

### DIFF
--- a/test/DataProvider/BooleanTest.php
+++ b/test/DataProvider/BooleanTest.php
@@ -23,7 +23,7 @@ final class BooleanTest extends AbstractTestCase
      *
      * @param bool $value
      */
-    public function testIsABoolean($value)
+    public function testIsBoolean($value)
     {
         $this->assertTrue(\is_bool($value));
     }

--- a/test/DataProvider/InvalidBooleanNotNullTest.php
+++ b/test/DataProvider/InvalidBooleanNotNullTest.php
@@ -23,7 +23,7 @@ final class InvalidBooleanNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotABoolean($value)
+    public function testIsNotBoolean($value)
     {
         $this->assertFalse(\is_bool($value));
     }

--- a/test/DataProvider/InvalidBooleanTest.php
+++ b/test/DataProvider/InvalidBooleanTest.php
@@ -23,7 +23,7 @@ final class InvalidBooleanTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotABoolean($value)
+    public function testIsNotBoolean($value)
     {
         $this->assertFalse(\is_bool($value));
     }

--- a/test/DataProvider/InvalidFloatNotNullTest.php
+++ b/test/DataProvider/InvalidFloatNotNullTest.php
@@ -23,7 +23,7 @@ final class InvalidFloatNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAFloat($value)
+    public function testIsNotFloat($value)
     {
         $this->assertFalse(\is_float($value));
     }

--- a/test/DataProvider/InvalidFloatTest.php
+++ b/test/DataProvider/InvalidFloatTest.php
@@ -23,7 +23,7 @@ final class InvalidFloatTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAFloat($value)
+    public function testIsNotFloat($value)
     {
         $this->assertFalse(\is_float($value));
     }

--- a/test/DataProvider/InvalidIntegerNotNullTest.php
+++ b/test/DataProvider/InvalidIntegerNotNullTest.php
@@ -23,7 +23,7 @@ final class InvalidIntegerNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAnInteger($value)
+    public function testIsNotInteger($value)
     {
         $this->assertFalse(\is_int($value));
     }

--- a/test/DataProvider/InvalidIntegerTest.php
+++ b/test/DataProvider/InvalidIntegerTest.php
@@ -23,7 +23,7 @@ final class InvalidIntegerTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAnInteger($value)
+    public function testIsNotInteger($value)
     {
         $this->assertFalse(\is_int($value));
     }

--- a/test/DataProvider/InvalidIntegerishTest.php
+++ b/test/DataProvider/InvalidIntegerishTest.php
@@ -24,7 +24,7 @@ final class InvalidIntegerishTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAnInteger($value)
+    public function testIsNotIntegerish($value)
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/test/DataProvider/InvalidIsoDateNotNullTest.php
+++ b/test/DataProvider/InvalidIsoDateNotNullTest.php
@@ -24,7 +24,7 @@ final class InvalidIsoDateNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAnIsoDate($value)
+    public function testIsNotIsoDate($value)
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/test/DataProvider/InvalidIsoDateTest.php
+++ b/test/DataProvider/InvalidIsoDateTest.php
@@ -24,7 +24,7 @@ final class InvalidIsoDateTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAnIsoDate($value)
+    public function testIsNotIsoDate($value)
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/test/DataProvider/InvalidScalarNotNullTest.php
+++ b/test/DataProvider/InvalidScalarNotNullTest.php
@@ -23,7 +23,7 @@ final class InvalidScalarNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAScalar($value)
+    public function testIsNotScalar($value)
     {
         $this->assertFalse(\is_scalar($value));
     }

--- a/test/DataProvider/InvalidScalarTest.php
+++ b/test/DataProvider/InvalidScalarTest.php
@@ -23,7 +23,7 @@ final class InvalidScalarTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAScalar($value)
+    public function testIsNotScalar($value)
     {
         $this->assertFalse(\is_scalar($value));
     }

--- a/test/DataProvider/InvalidStringNotNullTest.php
+++ b/test/DataProvider/InvalidStringNotNullTest.php
@@ -23,7 +23,7 @@ final class InvalidStringNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAString($value)
+    public function testIsNotString($value)
     {
         $this->assertFalse(\is_string($value));
     }

--- a/test/DataProvider/InvalidStringTest.php
+++ b/test/DataProvider/InvalidStringTest.php
@@ -23,7 +23,7 @@ final class InvalidStringTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAString($value)
+    public function testIsNotString($value)
     {
         $this->assertFalse(\is_string($value));
     }

--- a/test/DataProvider/InvalidUrlNotNullTest.php
+++ b/test/DataProvider/InvalidUrlNotNullTest.php
@@ -24,7 +24,7 @@ final class InvalidUrlNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAUrl($value)
+    public function testIsNotUrl($value)
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/test/DataProvider/InvalidUrlTest.php
+++ b/test/DataProvider/InvalidUrlTest.php
@@ -24,7 +24,7 @@ final class InvalidUrlTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAUrl($value)
+    public function testIsNotUrl($value)
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/test/DataProvider/InvalidUuidNotNullTest.php
+++ b/test/DataProvider/InvalidUuidNotNullTest.php
@@ -24,7 +24,7 @@ final class InvalidUuidNotNullTest extends AbstractNotNullTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAUuid($value)
+    public function testIsNotUuid($value)
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/test/DataProvider/InvalidUuidTest.php
+++ b/test/DataProvider/InvalidUuidTest.php
@@ -24,7 +24,7 @@ final class InvalidUuidTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsNotAUuid($value)
+    public function testIsNotUuid($value)
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/test/DataProvider/ScalarTest.php
+++ b/test/DataProvider/ScalarTest.php
@@ -23,7 +23,7 @@ final class ScalarTest extends AbstractTestCase
      *
      * @param mixed $value
      */
-    public function testIsAScalar($value)
+    public function testIsScalar($value)
     {
         $this->assertTrue(\is_scalar($value));
     }


### PR DESCRIPTION
This PR

* [x] streamlines test method names