### PR TITLE
Fix: Actually use key when providing data

### DIFF
--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -46,8 +46,8 @@ trait TestHelper
     final protected function provideData(array $values)
     {
         foreach ($values as $key => $value) {
-            yield [
-                $key => $value,
+            yield $key => [
+                $value,
             ];
         }
     }

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -641,11 +641,11 @@ final class TestHelperTest extends Framework\TestCase
     {
         $this->assertInstanceOf(\Traversable::class, $generator);
 
-        $expected = \array_map(function ($value, $key) {
+        $expected = \array_map(function ($value) {
             return [
-                $key => $value,
+                $value,
             ];
-        }, \array_values($values), \array_keys($values));
+        }, $values);
 
         $this->assertSame($expected, \iterator_to_array($generator));
     }


### PR DESCRIPTION
This PR

* [x] actually uses the key for identifying the data set when providing data

🤦‍♂️ 