### PR TITLE
Fix: Extract methods to avoid repetition

### DIFF
--- a/src/DataProvider/AbstractDataProvider.php
+++ b/src/DataProvider/AbstractDataProvider.php
@@ -19,4 +19,74 @@ abstract class AbstractDataProvider implements DataProviderInterface
     {
         return $this->provideData($this->values());
     }
+
+    /**
+     * @return string[]
+     */
+    final protected function arrayOfStrings()
+    {
+        return $this->getFaker()->words;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    final protected function dateTime()
+    {
+        return $this->getFaker()->dateTime;
+    }
+
+    /**
+     * @return float
+     */
+    final protected function floatNegative()
+    {
+        return -1 * $this->floatPositive();
+    }
+
+    /**
+     * @return float
+     */
+    final protected function floatPositive()
+    {
+        return $this->getFaker()->randomFloat(3, 0.001);
+    }
+
+    /**
+     * @return int
+     */
+    final protected function intNegative()
+    {
+        return -1 * $this->intPositive();
+    }
+
+    /**
+     * @return int
+     */
+    final protected function intPositive()
+    {
+        return $this->getFaker()->numberBetween(1);
+    }
+
+    /**
+     * @return resource
+     */
+    final protected function resource()
+    {
+        static $resource;
+
+        if (null === $resource) {
+            $resource = \fopen(__FILE__, 'r');
+        }
+
+        return $resource;
+    }
+
+    /**
+     * @return string
+     */
+    final protected function string()
+    {
+        return $this->getFaker()->word;
+    }
 }

--- a/src/DataProvider/InvalidBoolean.php
+++ b/src/DataProvider/InvalidBoolean.php
@@ -13,20 +13,18 @@ class InvalidBoolean extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array' => $faker->words,
-            'float-negative' => -1 * $faker->randomFloat(3, 0.001),
-            'float-positive' => $faker->randomFloat(3, 0.001),
+            'array' => $this->arrayOfStrings(),
+            'float-negative' => $this->floatNegative(),
+            'float-positive' => $this->floatPositive(),
             'float-zero' => 0.0,
-            'integer-negative' => -1 * $faker->numberBetween(1),
-            'integer-positive' => $faker->numberBetween(1),
+            'integer-negative' => $this->intNegative(),
+            'integer-positive' => $this->intPositive(),
             'integer-zero' => 0,
             'null' => null,
             'object' => new \stdClass(),
-            'resource' => \fopen(__FILE__, 'r'),
-            'string' => $faker->word,
+            'resource' => $this->resource(),
+            'string' => $this->string(),
         ];
     }
 }

--- a/src/DataProvider/InvalidFloat.php
+++ b/src/DataProvider/InvalidFloat.php
@@ -13,22 +13,20 @@ class InvalidFloat extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array' => $faker->words,
+            'array' => $this->arrayOfStrings(),
             'boolean-false' => false,
             'boolean-true' => true,
-            'float-negative-casted-to-string' => (string) (-1 * $faker->randomFloat(3, 0.001)),
-            'float-positive-casted-to-string' => (string) $faker->randomFloat(3, 0.001),
+            'float-negative-casted-to-string' => (string) $this->floatNegative(),
+            'float-positive-casted-to-string' => (string) $this->floatPositive(),
             'float-zero-casted-to-string' => (string) 0.0,
-            'integer-negative' => -1 * $faker->numberBetween(1),
-            'integer-positive' => $faker->numberBetween(1),
+            'integer-negative' => $this->intNegative(),
+            'integer-positive' => $this->intPositive(),
             'integer-zero' => 0,
             'null' => null,
             'object' => new \stdClass(),
-            'resource' => \fopen(__FILE__, 'r'),
-            'string' => $faker->word,
+            'resource' => $this->resource(),
+            'string' => $this->string(),
         ];
     }
 }

--- a/src/DataProvider/InvalidInteger.php
+++ b/src/DataProvider/InvalidInteger.php
@@ -13,22 +13,20 @@ class InvalidInteger extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array' => $faker->words,
+            'array' => $this->arrayOfStrings(),
             'boolean-false' => false,
             'boolean-true' => true,
-            'float-negative' => -1 * $faker->randomFloat(3, 0.001),
-            'float-positive' => $faker->randomFloat(3, 0.001),
+            'float-negative' => $this->floatNegative(),
+            'float-positive' => $this->floatPositive(),
             'float-zero' => 0.0,
-            'integer-negative-casted-to-string' => (string) (-1 * $faker->numberBetween(1)),
-            'integer-positive-casted-to-string' => (string) $faker->numberBetween(1),
+            'integer-negative-casted-to-string' => (string) $this->intNegative(),
+            'integer-positive-casted-to-string' => (string) $this->intPositive(),
             'integer-zero-casted-to-string' => (string) 0,
             'null' => null,
             'object' => new \stdClass(),
-            'resource' => \fopen(__FILE__, 'r'),
-            'string' => $faker->word,
+            'resource' => $this->resource(),
+            'string' => $this->string(),
         ];
     }
 }

--- a/src/DataProvider/InvalidIntegerish.php
+++ b/src/DataProvider/InvalidIntegerish.php
@@ -13,20 +13,18 @@ class InvalidIntegerish extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array' => $faker->words,
+            'array' => $this->arrayOfStrings(),
             'boolean-false' => false,
             'boolean-true' => true,
-            'float-negative' => -1 * $faker->randomFloat(3, 0.001),
-            'float-negative-casted-to-string' => (string) (-1 * $faker->randomFloat(3, 0.001)),
-            'float-positive' => $faker->randomFloat(3, 0.001),
-            'float-positive-casted-to-string' => (string) $faker->randomFloat(3, 0.001),
+            'float-negative' => $this->floatNegative(),
+            'float-negative-casted-to-string' => (string) $this->floatNegative(),
+            'float-positive' => $this->floatPositive(),
+            'float-positive-casted-to-string' => (string) $this->floatPositive(),
             'null' => null,
             'object' => new \stdClass(),
-            'resource' => \fopen(__FILE__, 'r'),
-            'string' => $faker->word,
+            'resource' => $this->resource(),
+            'string' => $this->string(),
         ];
     }
 }

--- a/src/DataProvider/InvalidIsoDate.php
+++ b/src/DataProvider/InvalidIsoDate.php
@@ -13,12 +13,10 @@ class InvalidIsoDate extends InvalidString
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
-        $date = $faker->dateTime;
+        $date = $this->dateTime();
 
         return \array_merge(parent::values(), [
-            'string' => $faker->word,
+            'string' => $this->string(),
             DATE_COOKIE => $date->format(DATE_COOKIE),
             DATE_ISO8601 => $date->format(DATE_ISO8601),
             DATE_RFC1036 => $date->format(DATE_RFC1036),

--- a/src/DataProvider/InvalidNumeric.php
+++ b/src/DataProvider/InvalidNumeric.php
@@ -13,16 +13,14 @@ class InvalidNumeric extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array' => $faker->words,
+            'array' => $this->arrayOfStrings(),
             'boolean-false' => false,
             'boolean-true' => true,
             'null' => null,
             'object' => new \stdClass(),
-            'resource' => \fopen(__FILE__, 'r'),
-            'string' => $faker->word,
+            'resource' => $this->resource(),
+            'string' => $this->string(),
         ];
     }
 }

--- a/src/DataProvider/InvalidScalar.php
+++ b/src/DataProvider/InvalidScalar.php
@@ -13,13 +13,11 @@ class InvalidScalar extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array' => $faker->words,
+            'array' => $this->arrayOfStrings(),
             'null' => null,
             'object' => new \stdClass(),
-            'resource' => \fopen(__FILE__, 'r'),
+            'resource' => $this->resource(),
         ];
     }
 }

--- a/src/DataProvider/InvalidString.php
+++ b/src/DataProvider/InvalidString.php
@@ -13,16 +13,14 @@ class InvalidString extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array' => $faker->words,
+            'array' => $this->arrayOfStrings(),
             'boolean-false' => false,
             'boolean-true' => true,
-            'float' => $faker->randomFloat(3, 0.001),
-            'integer' => $faker->numberBetween(1),
+            'float' => $this->floatPositive(),
+            'integer' => $this->intPositive(),
             'null' => null,
-            'resource' => \fopen(__FILE__, 'r'),
+            'resource' => $this->resource(),
             'object' => new \stdClass(),
         ];
     }

--- a/src/DataProvider/Scalar.php
+++ b/src/DataProvider/Scalar.php
@@ -13,18 +13,16 @@ class Scalar extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
             'boolean-false' => false,
             'boolean-true' => true,
-            'float-negative' => -1 * $faker->randomFloat(3, 0.001),
-            'float-positive' => $faker->randomFloat(3, 0.001),
+            'float-negative' => $this->floatNegative(),
+            'float-positive' => $this->floatPositive(),
             'float-zero' => 0.0,
-            'integer-negative' => -1 * $faker->numberBetween(1),
-            'integer-positive' => $faker->numberBetween(1),
+            'integer-negative' => $this->intNegative(),
+            'integer-positive' => $this->intPositive(),
             'integer-zero' => 0,
-            'string' => $faker->word,
+            'string' => $this->string(),
         ];
     }
 }

--- a/src/DataProvider/Truthy.php
+++ b/src/DataProvider/Truthy.php
@@ -16,17 +16,15 @@ class Truthy extends AbstractDataProvider
 {
     public function values()
     {
-        $faker = $this->getFaker();
-
         return [
-            'array-not-empty' => $faker->words(),
+            'array-not-empty' => $this->arrayOfStrings(),
             'boolean-true' => true,
-            'float-negative' => -1 * $faker->randomFloat(3, 0.001),
-            'float-positive' => $faker->randomFloat(3, 0.001),
-            'integer-negative' => -1 * $faker->numberBetween(1),
-            'integer-positive' => $faker->numberBetween(1),
+            'float-negative' => $this->floatNegative(),
+            'float-positive' => $this->floatPositive(),
+            'integer-negative' => $this->intNegative(),
+            'integer-positive' => $this->intPositive(),
             'object' => new \stdClass(),
-            'string-not-empty' => $faker->word,
+            'string-not-empty' => $this->string(),
         ];
     }
 }


### PR DESCRIPTION
This PR

* [x] extracts method so we avoid repetition and can control the returned data in one place

Blocks #162.