### PR TITLE
Fix: Remove support for traversable values

### DIFF
--- a/src/DataProvider/DataProviderInterface.php
+++ b/src/DataProvider/DataProviderInterface.php
@@ -12,9 +12,9 @@ namespace Refinery29\Test\Util\DataProvider;
 interface DataProviderInterface
 {
     /**
-     * This method should return an array or a Traversable.
+     * This method should return an array..
      *
-     * @return array|\Traversable
+     * @return array
      */
     public function values();
 }

--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -70,15 +70,9 @@ trait TestHelper
         $values = \array_reduce(
             $dataProviders,
             function (array $carry, DataProvider\DataProviderInterface $dataProvider) {
-                $values = $dataProvider->values();
-
-                if ($values instanceof \Traversable) {
-                    $values = \iterator_to_array($values);
-                }
-
                 return \array_merge(
                     $carry,
-                    $values
+                    $dataProvider->values()
                 );
             },
             []

--- a/test/DataProviderFake.php
+++ b/test/DataProviderFake.php
@@ -13,9 +13,12 @@ use Refinery29\Test\Util\DataProvider\DataProviderInterface;
 
 final class DataProviderFake implements DataProviderInterface
 {
+    /**
+     * @var array
+     */
     private $values;
 
-    public function __construct($values)
+    public function __construct(array $values)
     {
         $this->values = $values;
     }

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -139,7 +139,7 @@ final class TestHelperTest extends Framework\TestCase
         $this->assertGeneratorYieldsValues($values, $generator);
     }
 
-    public function testProvideDataFromYieldsValuesFromDataProviderWithArrayOfValues()
+    public function testProvideDataFromYieldsValuesFromDataProvider()
     {
         $faker = $this->getFaker();
 
@@ -148,25 +148,7 @@ final class TestHelperTest extends Framework\TestCase
             $faker->unique()->words(5)
         );
 
-        $dataProvider = new DataProviderFake($values);
-
-        $generator = $this->provideDataFrom($dataProvider);
-
-        $this->assertGeneratorYieldsValues($values, $generator);
-    }
-
-    public function testProvideDataFromYieldsValuesFromDataProviderWithTraversableYieldingValues()
-    {
-        $faker = $this->getFaker();
-
-        $values = \array_combine(
-            $faker->unique()->words(5),
-            $faker->unique()->words(5)
-        );
-
-        $dataProvider = new DataProviderFake($this->traversableFrom($values));
-
-        $generator = $this->provideDataFrom($dataProvider);
+        $generator = $this->provideDataFrom(new DataProviderFake($values));
 
         $this->assertGeneratorYieldsValues($values, $generator);
     }
@@ -186,8 +168,8 @@ final class TestHelperTest extends Framework\TestCase
         );
 
         $generator = $this->provideDataFrom(
-            new DataProviderFake($this->traversableFrom($valuesOne)),
-            new DataProviderFake($this->traversableFrom($valuesTwo))
+            new DataProviderFake($valuesOne),
+            new DataProviderFake($valuesTwo)
         );
 
         $values = \array_merge(


### PR DESCRIPTION
This PR

* [x] removes support for returning a `Traversable` from `DataProviderInterface::values()`

Blocks #161.

💁‍♂️ Not sure what the idea was, it's not used.