### PR TITLE
Fix: Remove unused method

### DIFF
--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -649,16 +649,4 @@ final class TestHelperTest extends Framework\TestCase
 
         $this->assertSame($expected, \iterator_to_array($generator));
     }
-
-    /**
-     * @param array $values
-     *
-     * @return \Generator
-     */
-    private function traversableFrom(array $values)
-    {
-        foreach ($values as $key => $value) {
-            yield $key => $value;
-        }
-    }
 }


### PR DESCRIPTION
This PR

* [x] removes an unused method

Follows #165.