### PR TITLE
Fix: Use at least 1 decimal

### DIFF
--- a/src/DataProvider/AbstractDataProvider.php
+++ b/src/DataProvider/AbstractDataProvider.php
@@ -46,14 +46,17 @@ abstract class AbstractDataProvider implements DataProviderInterface
 
     /**
      * @see https://github.com/fzaninotto/Faker/blob/v1.6.0/src/Faker/Provider/Base.php#L124-L138
+     * @see https://github.com/fzaninotto/Faker/blob/v1.6.0/src/Faker/Provider/Base.php#L40-L48
      * @see https://en.wikipedia.org/wiki/2147483647_(number)
      *
      * @return float
      */
     final protected function floatPositive()
     {
-        return $this->getFaker()->randomFloat(
-            null,
+        $faker = $this->getFaker();
+
+        return $faker->randomFloat(
+            $faker->randomDigitNotNull,
             1,
             2147483647
         );


### PR DESCRIPTION
This PR

* [x] uses at least 1 decimal when generating a `float`

🤦‍♂️ 