### PR TITLE
Fix: Use canonical path in assertClassesSatisfy()

### DIFF
--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -193,6 +193,8 @@ trait TestHelper
             ));
         }
 
+        $path = \realpath($path);
+
         \array_walk($excludeDirectories, function ($excludeDirectory) use ($path) {
             if (!\is_string($excludeDirectory)) {
                 throw new \InvalidArgumentException(\sprintf(


### PR DESCRIPTION
This PR

* [x] uses the canonical path in `assertClassesSatisfy()`