### PR TITLE
Enhancement: Add provideCombinedDataFrom()

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Quickly provide data from multiple concrete data providers using
 
 * `provideDataFrom(...$dataProviders) : \Generator`
 
+#### Providing combination of data from multiple concrete data providers
+
+Quickly combine data from multiple concrete data providers using
+
+* `provideCombinedDataFrom(...$dataProviders) : array`
+
 ### Data Providers
 
 If you need to assert that invalid values are rejected, you can use one

--- a/src/TestHelper.php
+++ b/src/TestHelper.php
@@ -82,6 +82,34 @@ trait TestHelper
     }
 
     /**
+     * @param DataProvider\DataProviderInterface[] ...$dataProviders
+     *
+     * @return array
+     */
+    final protected function provideCombinedDataFrom(DataProvider\DataProviderInterface ...$dataProviders)
+    {
+        /**
+         * @link https://stackoverflow.com/a/15973172
+         */
+        $values = [[]];
+
+        foreach ($dataProviders as $key => $provider) {
+            $append = [];
+
+            foreach ($values as $product) {
+                foreach ($provider->values() as $item) {
+                    $product[$key] = $item;
+                    $append[] = $product;
+                }
+            }
+
+            $values = $append;
+        }
+
+        return $values;
+    }
+
+    /**
      * @param string $className
      */
     final protected function assertFinal($className)

--- a/test/TestHelperTest.php
+++ b/test/TestHelperTest.php
@@ -180,6 +180,71 @@ final class TestHelperTest extends Framework\TestCase
         $this->assertGeneratorYieldsValues($values, $generator);
     }
 
+    public function testProvideCombinedDataFromYieldsValuesFromDataProvider()
+    {
+        $faker = $this->getFaker();
+
+        $values = $faker->unique()->words(5);
+
+        $expected = \array_map(function ($value) {
+            return [
+                $value,
+            ];
+        }, $values);
+
+        $result = $this->provideCombinedDataFrom(new DataProviderFake($values));
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testProvideCombinedDataFromYieldsCombinedValuesFromMultipleDataProviders()
+    {
+        $valuesOne = [
+            1,
+            2,
+            3,
+        ];
+
+        $valuesTwo = [
+            'a',
+            'b',
+        ];
+
+        $expected = [
+            [
+                1,
+                'a',
+            ],
+            [
+                1,
+                'b',
+            ],
+            [
+                2,
+                'a',
+            ],
+            [
+                2,
+                'b',
+            ],
+            [
+                3,
+                'a',
+            ],
+            [
+                3,
+                'b',
+            ],
+        ];
+
+        $result = $this->provideCombinedDataFrom(
+            new DataProviderFake($valuesOne),
+            new DataProviderFake($valuesTwo)
+        );
+
+        $this->assertEquals($expected, $result);
+    }
+
     public function testAssertFinalFailsWhenClassDoesNotExist()
     {
         $this->expectException(\PHPUnit_Framework_AssertionFailedError::class);


### PR DESCRIPTION
This PR

* [x] adds `provideCombinedDataFrom()`


Returns a cartesian product of given DataProviders such that given `[1,2]` and `[3,4]` it will return 

```
[ 
  [1,3],
  [1,4],
  [2,3],
  [2,4]
]
```

Useful when you need to test combination of data!
